### PR TITLE
Update all references std.builtin.Type, usually via @typeInfo, to following Zig naming conventions

### DIFF
--- a/src/bool.zig
+++ b/src/bool.zig
@@ -10,7 +10,7 @@ pub fn getBoolSize() usize {
 
 inline fn forceBoolType(value: anytype) type {
     const T = @TypeOf(value);
-    if (@typeInfo(T) == .Null) {
+    if (@typeInfo(T) == .null) {
         return ?bool;
     }
     assertBoolType(T);
@@ -19,8 +19,8 @@ inline fn forceBoolType(value: anytype) type {
 
 inline fn assertBoolType(T: type) void {
     switch (@typeInfo(T)) {
-        .Bool => return,
-        .Optional => |opt_info| {
+        .bool => return,
+        .optional => |opt_info| {
             return assertBoolType(opt_info.child);
         },
         else => @compileError("Expected bool, got " ++ @typeName(T)),

--- a/src/float.zig
+++ b/src/float.zig
@@ -7,8 +7,8 @@ const maybeUnpackNull = @import("null.zig").maybeUnpackNull;
 
 inline fn assertFloatType(comptime T: type) type {
     switch (@typeInfo(T)) {
-        .Float => return T,
-        .Optional => |opt_info| {
+        .float => return T,
+        .optional => |opt_info| {
             return assertFloatType(opt_info.child);
         },
         else => @compileError("Expected float, got " ++ @typeName(T)),

--- a/src/float.zig
+++ b/src/float.zig
@@ -32,7 +32,7 @@ pub fn packFloat(writer: anytype, comptime T: type, value_or_maybe_null: T) !voi
 
     comptime var TargetType: type = undefined;
     const type_info = @typeInfo(Type);
-    switch (type_info.Float.bits) {
+    switch (type_info.float.bits) {
         0...32 => {
             try writer.writeByte(hdrs.FLOAT32);
             TargetType = f32;
@@ -88,10 +88,10 @@ const packed_float64_inf = [_]u8{ 0xcb, 0x7f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00
 
 const float_types = [_]type{ f16, f32, f64 };
 
-fn minFloatType(comptime T1: type, comptime T2: type) type {
+fn MinFloatType(comptime T1: type, comptime T2: type) type {
     const ti1 = @typeInfo(T1);
     const ti2 = @typeInfo(T2);
-    return std.meta.Float(@min(ti1.Float.bits, ti2.Float.bits));
+    return std.meta.Float(@min(ti1.float.bits, ti2.float.bits));
 }
 
 test "readFloat: null" {
@@ -105,7 +105,7 @@ test "readFloat: float32 (zero)" {
     inline for (float_types) |T| {
         var stream = std.io.fixedBufferStream(&packed_float32_zero);
         const value = try unpackFloat(stream.reader(), T);
-        try std.testing.expectApproxEqAbs(0.0, value, std.math.floatEpsAt(minFloatType(T, f32), @floatCast(value)));
+        try std.testing.expectApproxEqAbs(0.0, value, std.math.floatEpsAt(MinFloatType(T, f32), @floatCast(value)));
     }
 }
 
@@ -113,7 +113,7 @@ test "readFloat: float64 (zero)" {
     inline for (float_types) |T| {
         var stream = std.io.fixedBufferStream(&packed_float64_zero);
         const value = try unpackFloat(stream.reader(), T);
-        try std.testing.expectApproxEqAbs(0.0, value, std.math.floatEpsAt(minFloatType(T, f64), @floatCast(value)));
+        try std.testing.expectApproxEqAbs(0.0, value, std.math.floatEpsAt(MinFloatType(T, f64), @floatCast(value)));
     }
 }
 
@@ -121,7 +121,7 @@ test "readFloat: float32 (pi)" {
     inline for (float_types) |T| {
         var stream = std.io.fixedBufferStream(&packed_float32_pi);
         const value = try unpackFloat(stream.reader(), T);
-        try std.testing.expectApproxEqAbs(std.math.pi, value, std.math.floatEpsAt(minFloatType(T, f32), @floatCast(value)));
+        try std.testing.expectApproxEqAbs(std.math.pi, value, std.math.floatEpsAt(MinFloatType(T, f32), @floatCast(value)));
     }
 }
 
@@ -129,7 +129,7 @@ test "readFloat: float64 (pi)" {
     inline for (float_types) |T| {
         var stream = std.io.fixedBufferStream(&packed_float64_pi);
         const value = try unpackFloat(stream.reader(), T);
-        try std.testing.expectApproxEqAbs(std.math.pi, value, std.math.floatEpsAt(minFloatType(T, f64), @floatCast(value)));
+        try std.testing.expectApproxEqAbs(std.math.pi, value, std.math.floatEpsAt(MinFloatType(T, f64), @floatCast(value)));
     }
 }
 

--- a/src/null.zig
+++ b/src/null.zig
@@ -18,7 +18,7 @@ pub fn unpackNull(reader: anytype) !void {
 }
 
 pub fn maybePackNull(writer: anytype, comptime T: type, value: T) !?NonOptional(T) {
-    if (@typeInfo(T) == .Optional) {
+    if (@typeInfo(T) == .optional) {
         if (value == null) {
             try packNull(writer);
             return null;

--- a/src/struct.zig
+++ b/src/struct.zig
@@ -92,7 +92,7 @@ fn strPrefix(src: []const u8, len: usize) []const u8 {
 
 pub fn packStructAsMap(writer: anytype, comptime T: type, value: T, comptime opts: StructAsMapOptions) !void {
     const type_info = @typeInfo(T);
-    const fields = type_info.Struct.fields;
+    const fields = type_info.@"struct".fields;
     const FieldEnum = std.meta.FieldEnum(T);
 
     try packMapHeader(writer, countUsedStructFields(fields, value, opts));
@@ -121,7 +121,7 @@ pub fn packStructAsMap(writer: anytype, comptime T: type, value: T, comptime opt
 
 pub fn packStructAsArray(writer: anytype, comptime T: type, value: T, comptime opts: StructAsArrayOptions) !void {
     const type_info = @typeInfo(T);
-    const fields = type_info.Struct.fields;
+    const fields = type_info.@"struct".fields;
 
     try packArrayHeader(writer, fields.len);
 
@@ -137,7 +137,7 @@ pub fn packStruct(writer: anytype, comptime T: type, value_or_maybe_null: T) !vo
     const Type = @TypeOf(value);
     const type_info = @typeInfo(Type);
 
-    if (type_info != .Struct) {
+    if (type_info != .@"struct") {
         @compileError("Expected struct type");
     }
 
@@ -158,14 +158,14 @@ pub fn packStruct(writer: anytype, comptime T: type, value_or_maybe_null: T) !vo
 }
 
 pub fn unpackStructAsMap(reader: anytype, allocator: std.mem.Allocator, comptime T: type, comptime opts: StructAsMapOptions) !T {
-    const len = if (@typeInfo(T) == .Optional)
+    const len = if (@typeInfo(T) == .optional)
         try unpackMapHeader(reader, ?u16) orelse return null
     else
         try unpackMapHeader(reader, u16);
 
     const Type = NonOptional(T);
     const type_info = @typeInfo(Type);
-    const fields = type_info.Struct.fields;
+    const fields = type_info.@"struct".fields;
     const FieldEnum = std.meta.FieldEnum(T);
 
     var fields_seen = std.bit_set.StaticBitSet(fields.len).initEmpty();
@@ -235,7 +235,7 @@ pub fn unpackStructAsMap(reader: anytype, allocator: std.mem.Allocator, comptime
                 const default_field_value = @as(*field.type, @ptrCast(@alignCast(@constCast(default_field_value_ptr)))).*;
                 @field(result, field.name) = default_field_value;
                 fields_seen.set(i);
-            } else if (@typeInfo(field.type) == .Optional) {
+            } else if (@typeInfo(field.type) == .optional) {
                 @field(result, field.name) = null;
                 fields_seen.set(i);
             }
@@ -257,7 +257,7 @@ pub fn unpackStructAsArray(reader: anytype, allocator: std.mem.Allocator, compti
 
     const Type = NonOptional(T);
     const type_info = @typeInfo(Type);
-    const fields = type_info.Struct.fields;
+    const fields = type_info.@"struct".fields;
 
     if (len != fields.len) {
         return error.InvalidFormat;

--- a/src/struct.zig
+++ b/src/struct.zig
@@ -66,7 +66,7 @@ fn isStructFieldUsed(field: std.builtin.Type.StructField, value: anytype, opts: 
     }
 
     if (opts.omit_nulls) {
-        if (field_type_info == .Optional) {
+        if (field_type_info == .optional) {
             if (field_value == null) {
                 return false;
             }
@@ -250,7 +250,7 @@ pub fn unpackStructAsMap(reader: anytype, allocator: std.mem.Allocator, comptime
 }
 
 pub fn unpackStructAsArray(reader: anytype, allocator: std.mem.Allocator, comptime T: type, comptime opts: StructAsArrayOptions) !T {
-    const len = if (@typeInfo(T) == .Optional)
+    const len = if (@typeInfo(T) == .optional)
         try unpackArrayHeader(reader, ?u16) orelse return null
     else
         try unpackArrayHeader(reader, u16);

--- a/src/union.zig
+++ b/src/union.zig
@@ -50,9 +50,9 @@ fn strPrefix(src: []const u8, len: usize) []const u8 {
 
 pub fn packUnionAsMap(writer: anytype, comptime T: type, value: T, opts: UnionAsMapOptions) !void {
     const type_info = @typeInfo(T);
-    const fields = type_info.Union.fields;
+    const fields = type_info.@"union".fields;
 
-    const TagType = @typeInfo(T).Union.tag_type.?;
+    const TagType = @typeInfo(T).@"union".tag_type.?;
 
     try packMapHeader(writer, 1);
 
@@ -79,7 +79,7 @@ pub fn packUnion(writer: anytype, comptime T: type, value_or_maybe_null: T) !voi
     const Type = @TypeOf(value);
     const type_info = @typeInfo(Type);
 
-    if (type_info != .Union) {
+    if (type_info != .@"union") {
         @compileError("Expected union type");
     }
 
@@ -92,7 +92,7 @@ pub fn packUnion(writer: anytype, comptime T: type, value_or_maybe_null: T) !voi
 }
 
 pub fn unpackUnionAsMap(reader: anytype, allocator: std.mem.Allocator, comptime T: type, opts: UnionAsMapOptions) !T {
-    const len = if (@typeInfo(T) == .Optional)
+    const len = if (@typeInfo(T) == .optional)
         try unpackMapHeader(reader, ?u16) orelse return null
     else
         try unpackMapHeader(reader, u16);
@@ -103,7 +103,7 @@ pub fn unpackUnionAsMap(reader: anytype, allocator: std.mem.Allocator, comptime 
 
     const Type = NonOptional(T);
     const type_info = @typeInfo(Type);
-    const fields = type_info.Union.fields;
+    const fields = type_info.@"union".fields;
 
     var field_name_buffer: [256]u8 = undefined;
 

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -2,8 +2,8 @@ const std = @import("std");
 
 pub fn NonOptional(comptime T: type) type {
     const type_info = @typeInfo(T);
-    if (type_info == .Optional) {
-        return type_info.Optional.child;
+    if (type_info == .optional) {
+        return type_info.optional.child;
     }
     return T;
 }
@@ -13,7 +13,7 @@ pub fn Optional(comptime T: type, comptime is_optional: bool) type {
 }
 
 pub inline fn isOptional(comptime T: type) bool {
-    return @typeInfo(T) == .Optional;
+    return @typeInfo(T) == .optional;
 }
 
 test isOptional {


### PR DESCRIPTION
The following breaking change was merged in this Zig PR: https://github.com/ziglang/zig/pull/21225 which means that on newer Zig versions all references to std.builtin.Type have to be updated to correctly reflect that, an example:
```zig
// new format matching naming conventions:
const type_info = @typeInfo(T);
const fields = type_info.@"struct".fields;

// previous to PR#21225
const type_info = @typeInfo(T);
const fields = type_info.Struct.fields;
```

I am on Zig version: `v0.14.0-dev.2270+a5d4ad17b` but older versions will also run into compiler errors. Not sure exactly where that PR ended up in relation to semver. Either way, I ran into it and the change was easy enough I figured I'd quickly submit this PR. 

```bash
test
└─ run test
   └─ zig test Debug native 7 errors
src/float.zig:35:23: error: no field named 'Float' in union 'builtin.Type'
    switch (type_info.Float.bits) {
                      ^~~~~
```

tests are passing on my machine, but if anything is wrong or needs changing feel free to reply/edit. :smile: 

~ Jules     