### PR TITLE
Migrate to Zig 0.15.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v1
+      - uses: mlugg/setup-zig@v2
         with:
-          version: 0.14.0
+          version: 0.15.1
       - run: zig build test --summary all

--- a/build.zig
+++ b/build.zig
@@ -9,9 +9,11 @@ pub fn build(b: *std.Build) !void {
     });
 
     const tests = b.addTest(.{
-        .root_source_file = b.path("src/msgpack.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/msgpack.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     const run_test = b.addRunArtifact(tests);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
     .name = .msgpack,
     .version = "0.4.0",
+    .minimum_zig_version = "0.15.1",
     .dependencies = .{},
     .fingerprint = 0x6733a7563cbdeb64,
     .paths = .{

--- a/src/enum.zig
+++ b/src/enum.zig
@@ -92,10 +92,10 @@ test "pack/unpack enum" {
     
     // Test plain enum
     {
-        var buffer = std.ArrayList(u8).init(std.testing.allocator);
-        defer buffer.deinit();
+        var buffer = std.ArrayList(u8){};
+        defer buffer.deinit(std.testing.allocator);
         
-        try packEnum(buffer.writer(), PlainEnum, .bar);
+        try packEnum(buffer.writer(std.testing.allocator), PlainEnum, .bar);
         
         var stream = std.io.fixedBufferStream(buffer.items);
         const result = try unpackEnum(stream.reader(), PlainEnum);
@@ -104,10 +104,10 @@ test "pack/unpack enum" {
     
     // Test enum(u8)
     {
-        var buffer = std.ArrayList(u8).init(std.testing.allocator);
-        defer buffer.deinit();
+        var buffer = std.ArrayList(u8){};
+        defer buffer.deinit(std.testing.allocator);
         
-        try packEnum(buffer.writer(), U8Enum, .bar);
+        try packEnum(buffer.writer(std.testing.allocator), U8Enum, .bar);
         
         var stream = std.io.fixedBufferStream(buffer.items);
         const result = try unpackEnum(stream.reader(), U8Enum);
@@ -116,10 +116,10 @@ test "pack/unpack enum" {
     
     // Test enum(u16) 
     {
-        var buffer = std.ArrayList(u8).init(std.testing.allocator);
-        defer buffer.deinit();
+        var buffer = std.ArrayList(u8){};
+        defer buffer.deinit(std.testing.allocator);
         
-        try packEnum(buffer.writer(), U16Enum, .alpha);
+        try packEnum(buffer.writer(std.testing.allocator), U16Enum, .alpha);
         
         var stream = std.io.fixedBufferStream(buffer.items);
         const result = try unpackEnum(stream.reader(), U16Enum);
@@ -137,10 +137,10 @@ test "enum edge cases" {
         fourth, // auto-assigned to 21
     };
     
-    var buffer = std.ArrayList(u8).init(std.testing.allocator);
-    defer buffer.deinit();
+    var buffer = std.ArrayList(u8){};
+    defer buffer.deinit(std.testing.allocator);
     
-    try packEnum(buffer.writer(), MixedEnum, .second);
+    try packEnum(buffer.writer(std.testing.allocator), MixedEnum, .second);
     
     var stream = std.io.fixedBufferStream(buffer.items);
     const result = try unpackEnum(stream.reader(), MixedEnum);
@@ -154,11 +154,11 @@ test "optional enum" {
     
     // Test non-null optional enum
     {
-        var buffer = std.ArrayList(u8).init(std.testing.allocator);
-        defer buffer.deinit();
+        var buffer = std.ArrayList(u8){};
+        defer buffer.deinit(std.testing.allocator);
         
         const value: OptionalEnum = .bar;
-        try packEnum(buffer.writer(), OptionalEnum, value);
+        try packEnum(buffer.writer(std.testing.allocator), OptionalEnum, value);
         
         var stream = std.io.fixedBufferStream(buffer.items);
         const result = try unpackEnum(stream.reader(), OptionalEnum);
@@ -167,11 +167,11 @@ test "optional enum" {
     
     // Test null optional enum
     {
-        var buffer = std.ArrayList(u8).init(std.testing.allocator);
-        defer buffer.deinit();
+        var buffer = std.ArrayList(u8){};
+        defer buffer.deinit(std.testing.allocator);
         
         const value: OptionalEnum = null;
-        try packEnum(buffer.writer(), OptionalEnum, value);
+        try packEnum(buffer.writer(std.testing.allocator), OptionalEnum, value);
         
         var stream = std.io.fixedBufferStream(buffer.items);
         const result = try unpackEnum(stream.reader(), OptionalEnum);

--- a/src/map.zig
+++ b/src/map.zig
@@ -111,10 +111,10 @@ test "packMap managed" {
 
     try map.put(1, 2);
 
-    var buf = std.ArrayList(u8).init(std.testing.allocator);
-    defer buf.deinit();
+    var buf = std.ArrayList(u8){};
+    defer buf.deinit(std.testing.allocator);
 
-    try packMap(buf.writer(), map);
+    try packMap(buf.writer(std.testing.allocator), map);
 
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0x81, 0x01, 0x02 }, buf.items);
 }
@@ -125,10 +125,10 @@ test "packMap unmanaged" {
 
     try map.put(1, 2);
 
-    var buf = std.ArrayList(u8).init(std.testing.allocator);
-    defer buf.deinit();
+    var buf = std.ArrayList(u8){};
+    defer buf.deinit(std.testing.allocator);
 
-    try packMap(buf.writer(), map.unmanaged);
+    try packMap(buf.writer(std.testing.allocator), map.unmanaged);
 
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0x81, 0x01, 0x02 }, buf.items);
 }

--- a/src/msgpack.zig
+++ b/src/msgpack.zig
@@ -303,13 +303,13 @@ test "encode/decode" {
         age: u8,
     };
 
-    var buffer = std.ArrayList(u8).init(std.testing.allocator);
-    defer buffer.deinit();
+    var buffer = std.ArrayList(u8){};
+    defer buffer.deinit(std.testing.allocator);
 
     try encode(Message{
         .name = "John",
         .age = 20,
-    }, buffer.writer());
+    }, buffer.writer(std.testing.allocator));
 
     const decoded = try decodeFromSlice(Message, std.testing.allocator, buffer.items);
     defer decoded.deinit();
@@ -324,10 +324,10 @@ test "encode/decode enum" {
     
     // Test enum(u8)
     {
-        var buffer = std.ArrayList(u8).init(std.testing.allocator);
-        defer buffer.deinit();
+        var buffer = std.ArrayList(u8){};
+        defer buffer.deinit(std.testing.allocator);
         
-        try encode(Status.active, buffer.writer());
+        try encode(Status.active, buffer.writer(std.testing.allocator));
         
         const decoded = try decodeFromSlice(Status, std.testing.allocator, buffer.items);
         defer decoded.deinit();
@@ -337,10 +337,10 @@ test "encode/decode enum" {
     
     // Test plain enum  
     {
-        var buffer = std.ArrayList(u8).init(std.testing.allocator);
-        defer buffer.deinit();
+        var buffer = std.ArrayList(u8){};
+        defer buffer.deinit(std.testing.allocator);
         
-        try encode(PlainEnum.bar, buffer.writer());
+        try encode(PlainEnum.bar, buffer.writer(std.testing.allocator));
         
         const decoded = try decodeFromSlice(PlainEnum, std.testing.allocator, buffer.items);
         defer decoded.deinit();
@@ -350,10 +350,10 @@ test "encode/decode enum" {
     
     // Test optional enum with null
     {
-        var buffer = std.ArrayList(u8).init(std.testing.allocator);
-        defer buffer.deinit();
+        var buffer = std.ArrayList(u8){};
+        defer buffer.deinit(std.testing.allocator);
         
-        try encode(@as(?Status, null), buffer.writer());
+        try encode(@as(?Status, null), buffer.writer(std.testing.allocator));
         
         const decoded = try decodeFromSlice(?Status, std.testing.allocator, buffer.items);
         defer decoded.deinit();
@@ -363,10 +363,10 @@ test "encode/decode enum" {
     
     // Test optional enum with value
     {
-        var buffer = std.ArrayList(u8).init(std.testing.allocator);
-        defer buffer.deinit();
+        var buffer = std.ArrayList(u8){};
+        defer buffer.deinit(std.testing.allocator);
         
-        try encode(@as(?Status, .pending), buffer.writer());
+        try encode(@as(?Status, .pending), buffer.writer(std.testing.allocator));
         
         const decoded = try decodeFromSlice(?Status, std.testing.allocator, buffer.items);
         defer decoded.deinit();


### PR DESCRIPTION
Port msgpack.zig to Zig 0.15.1

## Changes

- **build.zig**: Update `addTest()` to use `createModule()` with `root_module` parameter
- **ArrayList API**: Update to new allocator-passing pattern:
  - `ArrayList(T).init(allocator)` → `ArrayList(T){}`
  - `.deinit()` → `.deinit(allocator)`
  - `.writer()` → `.writer(allocator)`
- **CI**: Update to `setup-zig@v2` with Zig 0.15.1
- **build.zig.zon**: Set `minimum_zig_version = "0.15.1"`

## Test Results

✓ All 131 tests passing