### PR TITLE
build: support zig 0.16

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .name = .msgpack,
     .version = "0.6.0",
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{},
     .fingerprint = 0x6733a7563cbdeb64,
     .paths = .{

--- a/src/struct.zig
+++ b/src/struct.zig
@@ -75,7 +75,7 @@ fn isStructFieldUsed(field: std.builtin.Type.StructField, value: anytype, opts: 
     return true;
 }
 
-fn countUsedStructFields(fields: []const std.builtin.Type.StructField, value: anytype, opts: StructAsMapOptions) u16 {
+fn countUsedStructFields(comptime fields: []const std.builtin.Type.StructField, value: anytype, opts: StructAsMapOptions) u16 {
     var used_field_count: u16 = 0;
     inline for (fields) |field| {
         if (isStructFieldUsed(field, value, opts)) {

--- a/src/union.zig
+++ b/src/union.zig
@@ -244,7 +244,7 @@ pub fn unpackUnionAsTagged(reader: *std.Io.Reader, allocator: std.mem.Allocator,
             const field_name = try unpackStringInto(reader, &tag_value_buffer);
             union_field_name = field_name;
         },
-        .field_name_prefix => |_| {
+        .field_name_prefix => {
             const field_name = try unpackStringInto(reader, &tag_value_buffer);
             union_field_name = field_name;
         },


### PR DESCRIPTION
## Summary

- require Zig 0.16.0 in `build.zig.zon`
- mark the struct field slice as comptime for the `inline for` helper
- remove an unused tagged-union payload capture rejected by Zig 0.16

## Tests

- `./check.sh --ci`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Zig toolchain requirement to version 0.16.0.

* **Refactor**
  * Internal code improvements and optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->