### PR TITLE
fix: correct array and map header sizes

### DIFF
--- a/src/array.zig
+++ b/src/array.zig
@@ -16,8 +16,6 @@ const unpackAny = @import("any.zig").unpackAny;
 pub fn sizeOfPackedArrayHeader(len: usize) !usize {
     if (len <= hdrs.FIXARRAY_MAX - hdrs.FIXARRAY_MIN) {
         return 1;
-    } else if (len <= std.math.maxInt(u8)) {
-        return 1 + @sizeOf(u8);
     } else if (len <= std.math.maxInt(u16)) {
         return 1 + @sizeOf(u16);
     } else if (len <= std.math.maxInt(u32)) {
@@ -140,4 +138,8 @@ test "packArray: null" {
 
 test "sizeOfPackedArray" {
     try std.testing.expectEqual(1, sizeOfPackedArray(0));
+}
+
+test "sizeOfPackedArrayHeader: array16 boundary" {
+    try std.testing.expectEqual(3, sizeOfPackedArrayHeader(16));
 }

--- a/src/map.zig
+++ b/src/map.zig
@@ -17,8 +17,6 @@ const unpackAny = @import("any.zig").unpackAny;
 pub fn sizeOfPackedMapHeader(len: usize) !usize {
     if (len <= hdrs.FIXMAP_MAX - hdrs.FIXMAP_MIN) {
         return 1;
-    } else if (len <= std.math.maxInt(u8)) {
-        return 1 + @sizeOf(u8);
     } else if (len <= std.math.maxInt(u16)) {
         return 1 + @sizeOf(u16);
     } else if (len <= std.math.maxInt(u32)) {
@@ -155,4 +153,8 @@ test "unpackMap unmanaged" {
 
 test "sizeOfPackedMap" {
     try std.testing.expectEqual(1, sizeOfPackedMap(0));
+}
+
+test "sizeOfPackedMapHeader: map16 boundary" {
+    try std.testing.expectEqual(3, sizeOfPackedMapHeader(16));
 }


### PR DESCRIPTION
## Summary

- remove nonexistent array8/map8 size branches
- add boundary tests for the first array16/map16 sizes

## Bug

MessagePack has fixarray for lengths 0-15 and then array16/array32. It does not have an array8 format. Likewise, MessagePack has fixmap for lengths 0-15 and then map16/map32, with no map8 format.

The size helpers had an extra `u8` branch after the fixarray/fixmap range, so `sizeOfPackedArrayHeader(16)` and `sizeOfPackedMapHeader(16)` returned `2`. The actual encoded header is `ARRAY16`/`MAP16`, which is one tag byte plus a two-byte length, so the correct size is `3`.

The new tests demonstrate the failure at that boundary before the fix.

## Tests

- `env PATH=/Users/banteg/.cache/zig/toolchains/zig-aarch64-macos-0.15.1:$PATH zig build test --summary all` failed before the fix with both boundary tests returning `2`
- `env PATH=/Users/banteg/.cache/zig/toolchains/zig-aarch64-macos-0.15.1:$PATH ./check.sh --ci`
