### PR TITLE
fix: make Unpacker.readArray usable

### DIFF
--- a/src/array.zig
+++ b/src/array.zig
@@ -107,11 +107,11 @@ pub fn Array(comptime T: type) type {
         data: []T,
 
         pub fn msgpackWrite(self: @This(), packer: anytype) !void {
-            try packer.writeArray(self.data);
+            try packer.writeArray(T, self.data);
         }
 
         pub fn msgpackRead(unpacker: anytype) !@This() {
-            const data = try unpacker.readArray([]T);
+            const data = try unpacker.readArray(T);
             return .{ .data = data };
         }
     };
@@ -140,4 +140,19 @@ test "sizeOfPackedArray" {
 
 test "sizeOfPackedArrayHeader: array16 boundary" {
     try std.testing.expectEqual(3, sizeOfPackedArrayHeader(16));
+}
+
+test "Array wrapper round trip" {
+    const packed_u32_array = [_]u8{ 0x93, 0x01, 0x02, 0x03 };
+    var items = [_]u32{ 1, 2, 3 };
+
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try packAny(&aw.writer, Array(u32){ .data = &items });
+    try std.testing.expectEqualSlices(u8, &packed_u32_array, aw.written());
+
+    var reader = std.Io.Reader.fixed(aw.written());
+    const decoded = try unpackAny(&reader, std.testing.allocator, Array(u32));
+    defer std.testing.allocator.free(decoded.data);
+    try std.testing.expectEqualSlices(u32, &items, decoded.data);
 }

--- a/src/msgpack.zig
+++ b/src/msgpack.zig
@@ -206,7 +206,7 @@ pub const Unpacker = struct {
     }
 
     pub fn readArray(self: Unpacker, comptime T: type) ![]T {
-        return unpackArray(self.reader, self.allocator, T);
+        return unpackArray(self.reader, self.allocator, []T);
     }
 
     pub fn readArrayInto(self: Unpacker, comptime T: type, buffer: []T) ![]T {
@@ -486,4 +486,41 @@ test "unpacker readBinary reads bin8" {
     const value = try unpacker(&reader, std.testing.allocator).readBinary();
     defer std.testing.allocator.free(value);
     try std.testing.expectEqualSlices(u8, "abc", value);
+}
+
+test "unpacker readArray takes the element type" {
+    // `refAllDecls` does not instantiate generic functions, so a signature
+    // mismatch here stays invisible until something actually calls it.
+    const packed_u32_array = [_]u8{ 0x93, 0x01, 0x02, 0x03 };
+    var reader = std.Io.Reader.fixed(&packed_u32_array);
+    const value = try unpacker(&reader, std.testing.allocator).readArray(u32);
+    defer std.testing.allocator.free(value);
+    try std.testing.expectEqualSlices(u32, &[_]u32{ 1, 2, 3 }, value);
+}
+
+test "custom msgpackWrite/msgpackRead using writeArray and readArray" {
+    // The "completely custom format" example from README.md, verbatim.
+    const Message = struct {
+        items: []u32,
+
+        pub fn msgpackWrite(self: @This(), p: anytype) !void {
+            try p.writeArray(u32, self.items);
+        }
+
+        pub fn msgpackRead(u: anytype) !@This() {
+            const items = try u.readArray(u32);
+            return .{ .items = items };
+        }
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+
+    var items = [_]u32{ 1, 2, 3 };
+    try encode(Message{ .items = &items }, &aw.writer);
+
+    const decoded = try decodeFromSlice(Message, std.testing.allocator, aw.written());
+    defer decoded.deinit();
+
+    try std.testing.expectEqualSlices(u32, &items, decoded.value.items);
 }


### PR DESCRIPTION
Fixes #21.

`Unpacker.readArray` passes its type parameter straight through to `unpackArray`, but the two disagree about what that parameter means:

```zig
pub fn readArray(self: Unpacker, comptime T: type) ![]T {
    return unpackArray(self.reader, self.allocator, T);
}
```

`unpackArray` expects the **slice** type — it derives the element type itself via `std.meta.Child` and returns `T`. `readArray` declares `![]T`, i.e. it treats `T` as the **element** type. Both readings fail, so the method cannot be instantiated with any argument:

- `readArray(u32)` → *"Expected pointer, optional, array or vector type, found 'u32'"*
- `readArray([]u32)` → *"pointer type child 'u32' cannot cast into pointer type child '[]u32'"*

The fix passes the slice type down, keeping the element-type convention that `Packer.writeArray` and `Unpacker.readArrayInto` already use.

## This broke the README

The "Or you can use a completely custom format" example calls `unpacker.readArray(u32)`, so it did not compile as written. It is now a test, verbatim.

## Array(T)

The same mismatch hid two more errors in the `Array(T)` helper in `src/array.zig`, which nothing in the repo constructs: `msgpackWrite` called `writeArray` with one argument where it takes two, and `msgpackRead` passed the slice type where the element type belongs. Both fixed, with a round-trip test so the generic is actually instantiated. The neighbouring `String` and `Binary` helpers were already fine.

## Why CI was green

`test { _ = std.testing.refAllDecls(@This()); }` does not instantiate generic functions, so nothing ever type-checked these. The three tests added here call the affected paths directly. Reverting the one-line fix makes them fail to compile, so they hold the line.

`zig build test`: 156/156 pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed serialization and deserialization for typed arrays, including `Array` wrappers and raw arrays.
  - Typed arrays now preserve their element types correctly when packed and unpacked.
  - Improved compatibility for custom message-pack formats that use array read/write operations.

- **Tests**
  - Added coverage for typed array round trips and custom serialization formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->