### PR TITLE
fix: make Unpacker.readUnion usable

### DIFF
--- a/src/msgpack.zig
+++ b/src/msgpack.zig
@@ -229,7 +229,7 @@ pub const Unpacker = struct {
         return unpackStruct(self.reader, self.allocator, T);
     }
 
-    pub fn readUnion(self: Unpacker, comptime T: type) !?T {
+    pub fn readUnion(self: Unpacker, comptime T: type) !T {
         return unpackUnion(self.reader, self.allocator, T);
     }
 
@@ -486,4 +486,26 @@ test "unpacker readBinary reads bin8" {
     const value = try unpacker(&reader, std.testing.allocator).readBinary();
     defer std.testing.allocator.free(value);
     try std.testing.expectEqualSlices(u8, "abc", value);
+}
+
+test "unpacker readUnion" {
+    // `refAllDecls` does not instantiate generic functions, so a signature
+    // mismatch here stays invisible until something actually calls it.
+    const Value = union(enum) { a: u8, b: u16 };
+
+    const packed_union_a = [_]u8{ 0x81, 0xa1, 'a', 0x01 };
+    var reader = std.Io.Reader.fixed(&packed_union_a);
+    try std.testing.expectEqual(
+        Value{ .a = 1 },
+        try unpacker(&reader, std.testing.allocator).readUnion(Value),
+    );
+
+    // An optional union is expressed by asking for `?Value`, which
+    // `unpackUnion` already handles.
+    const packed_null_union = [_]u8{0xc0};
+    var null_reader = std.Io.Reader.fixed(&packed_null_union);
+    try std.testing.expectEqual(
+        @as(?Value, null),
+        try unpacker(&null_reader, std.testing.allocator).readUnion(?Value),
+    );
 }


### PR DESCRIPTION
Fixes #22.

`Unpacker.readUnion` promises one more level of optional than `unpackUnion` returns, so it cannot be instantiated with any type argument:

```zig
pub fn readUnion(self: Unpacker, comptime T: type) !?T {
    return unpackUnion(self.reader, self.allocator, T);
}
```

`unpackUnion` returns `!T` and already handles the optional case internally, via `NonOptional(T)` and the `?u16` map-header path. The extra `?` makes both readings a type error:

- `readUnion(U)` → *"error union payload 'U' cannot cast into error union payload '?U'"*
- `readUnion(?U)` → *"optional type child 'U' cannot cast into optional type child '?U'"*

Returning `!T` matches how `readStruct` forwards to `unpackStruct`. Callers wanting the nullable behaviour pass `?U`, which `unpackUnion` already supports — the added test covers both.

## Why CI was green

Same reason as #21: `refAllDecls` does not instantiate generic functions, so nothing ever type-checked this. Reverting the signature makes the new test fail to compile.

I exercised every other method on `Packer` and `Unpacker` once each while investigating; this and `readArray` (#21, PR #25) were the only two that were uninstantiable. Everything else compiles and round trips.

`zig build test`: 154/154 pass.
