### PR TITLE
chore: remove broken and unreachable size API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+- `sizeOfPackedArray` and `sizeOfPackedMap`, which added the *element count* to
+  the header size as if every element encoded to one byte, and so under-reported
+  the encoded size of any array or map whose elements are not single bytes. The
+  header functions `sizeOfPackedArrayHeader` and `sizeOfPackedMapHeader` are
+  correct and remain, as do `sizeOfPackedString` and `sizeOfPackedStringHeader`.
+- `Packer.getArrayHeaderSize` and `Packer.getMapHeaderSize`, which were declared
+  without a `self` parameter and so were never callable as methods. Call
+  `sizeOfPackedArrayHeader` / `sizeOfPackedMapHeader` directly instead.
+- The internal `sizeOfPackedAny` and `sizeOfPackedBinary`, neither of which was
+  ever exported or called.
+
+To compute an encoded size, encode into a counting writer rather than predicting
+the size separately; that reuses the encoder and cannot drift from it.
+
 ## [0.7.0] - 2026-04-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Removed
-- `sizeOfPackedArray` and `sizeOfPackedMap`, which added the *element count* to
-  the header size as if every element encoded to one byte, and so under-reported
-  the encoded size of any array or map whose elements are not single bytes. The
-  header functions `sizeOfPackedArrayHeader` and `sizeOfPackedMapHeader` are
-  correct and remain, as do `sizeOfPackedString` and `sizeOfPackedStringHeader`.
-- `Packer.getArrayHeaderSize` and `Packer.getMapHeaderSize`, which were declared
-  without a `self` parameter and so were never callable as methods. Call
-  `sizeOfPackedArrayHeader` / `sizeOfPackedMapHeader` directly instead.
-- The internal `sizeOfPackedAny` and `sizeOfPackedBinary`, neither of which was
-  ever exported or called.
-
-To compute an encoded size, encode into a counting writer rather than predicting
-the size separately; that reuses the encoder and cannot drift from it.
+- `sizeOfPackedArray` and `sizeOfPackedMap`, which under-reported sizes by adding the element count to the header size; the `sizeOfPackedArrayHeader` and `sizeOfPackedMapHeader` variants are correct and remain
+- `Packer.getArrayHeaderSize` and `Packer.getMapHeaderSize`; call `sizeOfPackedArrayHeader` and `sizeOfPackedMapHeader` directly
 
 ## [0.7.0] - 2026-04-30
 

--- a/src/any.zig
+++ b/src/any.zig
@@ -1,31 +1,22 @@
 const std = @import("std");
-const hdrs = @import("headers.zig");
 
-const NonOptional = @import("utils.zig").NonOptional;
-
-const getNullSize = @import("null.zig").getNullSize;
 const packNull = @import("null.zig").packNull;
 const unpackNull = @import("null.zig").unpackNull;
 
-const getBoolSize = @import("bool.zig").getBoolSize;
 const packBool = @import("bool.zig").packBool;
 const unpackBool = @import("bool.zig").unpackBool;
 
-const getIntSize = @import("int.zig").getIntSize;
 const packInt = @import("int.zig").packInt;
 const unpackInt = @import("int.zig").unpackInt;
 
-const getFloatSize = @import("float.zig").getFloatSize;
 const packFloat = @import("float.zig").packFloat;
 const unpackFloat = @import("float.zig").unpackFloat;
 
-const sizeOfPackedString = @import("string.zig").sizeOfPackedString;
 const packString = @import("string.zig").packString;
 const unpackString = @import("string.zig").unpackString;
 const String = @import("string.zig").String;
 const Binary = @import("binary.zig").Binary;
 
-const sizeOfPackedArray = @import("array.zig").sizeOfPackedArray;
 const packArray = @import("array.zig").packArray;
 const unpackArray = @import("array.zig").unpackArray;
 
@@ -35,7 +26,6 @@ const unpackStruct = @import("struct.zig").unpackStruct;
 const packUnion = @import("union.zig").packUnion;
 const unpackUnion = @import("union.zig").unpackUnion;
 
-const getEnumSize = @import("enum.zig").getEnumSize;
 const packEnum = @import("enum.zig").packEnum;
 const unpackEnum = @import("enum.zig").unpackEnum;
 
@@ -54,33 +44,6 @@ inline fn isString(comptime T: type) bool {
         else => {},
     }
     return false;
-}
-
-pub fn sizeOfPackedAny(comptime T: type, value: T) !usize {
-    if (@typeInfo(T) == .optional) {
-        if (value) |v| {
-            return sizeOfPackedAny(@TypeOf(v), v);
-        }
-        return getNullSize();
-    }
-
-    switch (@typeInfo(NonOptional(T))) {
-        .bool => return getBoolSize(),
-        .int => return getIntSize(T, value),
-        .float => return getFloatSize(T, value),
-        .@"enum" => return getEnumSize(T, value),
-        .pointer => |ptr_info| {
-            if (ptr_info.size == .slice) {
-                if (isString(T)) {
-                    return try sizeOfPackedString(value.len);
-                } else {
-                    return try sizeOfPackedArray(value.len);
-                }
-            }
-        },
-        else => {},
-    }
-    @compileError("Unsupported type '" ++ @typeName(T) ++ "'");
 }
 
 pub fn packAny(writer: *std.Io.Writer, value: anytype) !void {
@@ -383,18 +346,4 @@ test "packAny/unpackAny: Binary struct" {
     const result = try unpackAny(&reader, std.testing.allocator, Binary);
     defer std.testing.allocator.free(result.data);
     try std.testing.expectEqualSlices(u8, "\x01\x02\x03\x04", result.data);
-}
-
-test "sizeOfPackedAny: string slice" {
-    try std.testing.expectEqual(4, try sizeOfPackedAny([]const u8, "abc"));
-}
-
-test "sizeOfPackedAny: array slice" {
-    const values = [_]u16{ 1, 2, 3 };
-    try std.testing.expectEqual(4, try sizeOfPackedAny([]const u16, &values));
-}
-
-test "sizeOfPackedAny: optional null and value" {
-    try std.testing.expectEqual(1, try sizeOfPackedAny(?[]const u8, null));
-    try std.testing.expectEqual(4, try sizeOfPackedAny(?[]const u8, "abc"));
 }

--- a/src/array.zig
+++ b/src/array.zig
@@ -25,10 +25,6 @@ pub fn sizeOfPackedArrayHeader(len: usize) !usize {
     }
 }
 
-pub fn sizeOfPackedArray(len: usize) !usize {
-    return try sizeOfPackedArrayHeader(len) + len;
-}
-
 pub fn packArrayHeader(writer: *std.Io.Writer, len: usize) !void {
     if (len <= hdrs.FIXARRAY_MAX - hdrs.FIXARRAY_MIN) {
         try writer.writeByte(hdrs.FIXARRAY_MIN + @as(u8, @intCast(len)));
@@ -132,10 +128,6 @@ test "packArray: null" {
     var writer = std.Io.Writer.fixed(&buffer);
     try packArray(&writer, ?[]const u8, null);
     try std.testing.expectEqualSlices(u8, &packed_null, writer.buffered());
-}
-
-test "sizeOfPackedArray" {
-    try std.testing.expectEqual(1, sizeOfPackedArray(0));
 }
 
 test "sizeOfPackedArrayHeader: array16 boundary" {

--- a/src/binary.zig
+++ b/src/binary.zig
@@ -23,10 +23,6 @@ pub fn sizeOfPackedBinaryHeader(len: usize) !usize {
     }
 }
 
-pub fn sizeOfPackedBinary(len: usize) !usize {
-    return try sizeOfPackedBinaryHeader(len) + len;
-}
-
 pub fn packBinaryHeader(writer: *std.Io.Writer, len: usize) !void {
     if (len <= std.math.maxInt(u8)) {
         try packHeaderAndInt(writer, hdrs.BIN8, u8, @intCast(len));
@@ -125,8 +121,4 @@ test "packBinary: null" {
     var writer = std.Io.Writer.fixed(&buffer);
     try packBinary(&writer, ?[]const u8, null);
     try std.testing.expectEqualSlices(u8, &packed_null, writer.buffered());
-}
-
-test "sizeOfPackedBinary" {
-    try std.testing.expectEqual(2, sizeOfPackedBinary(0));
 }

--- a/src/map.zig
+++ b/src/map.zig
@@ -26,10 +26,6 @@ pub fn sizeOfPackedMapHeader(len: usize) !usize {
     }
 }
 
-pub fn sizeOfPackedMap(len: usize) !usize {
-    return try sizeOfPackedMapHeader(len) + len;
-}
-
 pub fn packMapHeader(writer: *std.Io.Writer, len: usize) !void {
     if (len <= hdrs.FIXMAP_MAX - hdrs.FIXMAP_MIN) {
         try writer.writeByte(hdrs.FIXMAP_MIN + @as(u8, @intCast(len)));
@@ -147,10 +143,6 @@ test "unpackMap unmanaged" {
     defer map.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(2, map.get(1));
-}
-
-test "sizeOfPackedMap" {
-    try std.testing.expectEqual(1, sizeOfPackedMap(0));
 }
 
 test "sizeOfPackedMapHeader: map16 boundary" {

--- a/src/msgpack.zig
+++ b/src/msgpack.zig
@@ -22,12 +22,10 @@ pub const getMaxFloatSize = @import("float.zig").getMaxFloatSize;
 pub const packFloat = @import("float.zig").packFloat;
 pub const unpackFloat = @import("float.zig").unpackFloat;
 
-pub const sizeOfPackedArray = @import("array.zig").sizeOfPackedArray;
 pub const sizeOfPackedArrayHeader = @import("array.zig").sizeOfPackedArrayHeader;
 pub const packArray = @import("array.zig").packArray;
 pub const packArrayHeader = @import("array.zig").packArrayHeader;
 
-pub const sizeOfPackedMap = @import("map.zig").sizeOfPackedMap;
 pub const sizeOfPackedMapHeader = @import("map.zig").sizeOfPackedMapHeader;
 pub const packMap = @import("map.zig").packMap;
 pub const packMapHeader = @import("map.zig").packMapHeader;
@@ -113,20 +111,12 @@ pub const Packer = struct {
         return packBinary(self.writer, []const u8, value);
     }
 
-    pub fn getArrayHeaderSize(len: usize) !usize {
-        return sizeOfPackedArrayHeader(len);
-    }
-
     pub fn writeArrayHeader(self: Packer, len: usize) !void {
         return packArrayHeader(self.writer, len);
     }
 
     pub fn writeArray(self: Packer, comptime T: type, value: []const T) !void {
         return packArray(self.writer, @TypeOf(value), value);
-    }
-
-    pub fn getMapHeaderSize(len: usize) !usize {
-        return sizeOfPackedMapHeader(len);
     }
 
     pub fn writeMapHeader(self: Packer, len: usize) !void {


### PR DESCRIPTION
Fixes #23.

Removes the parts of the size API that are wrong or unreachable, and keeps the parts that work.

## Removed

**`sizeOfPackedArray` / `sizeOfPackedMap`** — both computed `header_size + len`, treating the element count as a byte count. That identity holds for strings, where `len` really is bytes, but not for arrays or maps:

| value | reported | actual |
|---|---|---|
| `[]const u16{1000, 2000, 3000}` | 4 | 10 |
| `[]const []const u8{"hello", "world"}` | 3 | 13 |

Under-reporting is the dangerous direction — the result is a buffer too small to encode into. The existing test used `{1, 2, 3}`, which are all single-byte fixints, so `header + count` came out right by coincidence and the bug stayed hidden.

**`Packer.getArrayHeaderSize` / `Packer.getMapHeaderSize`** — declared without a `self` parameter, unlike every sibling method, so `p.getArrayHeaderSize(n)` fails with *"no field or member function named 'getArrayHeaderSize' in 'msgpack.Packer'"*. They shipped that way in the initial commit and were never called. Use `sizeOfPackedArrayHeader` / `sizeOfPackedMapHeader` directly.

**`sizeOfPackedAny`** — never exported in any commit, so the only function that could size a whole value was unreachable from outside the library. It was also uncompilable: it carried the pre-0.14 `.Slice` enum name until April 2026, because the Zig 0.14 port renamed three of the four occurrences in `any.zig` and missed this one. CI stayed green throughout, since `refAllDecls` does not instantiate generic functions — the same hole behind #21 and #22.

**`sizeOfPackedBinary`** — never exported, never called.

## Kept

- `sizeOfPackedArrayHeader`, `sizeOfPackedMapHeader`, `sizeOfPackedStringHeader`, `sizeOfPackedBinaryHeader` — all correct. The array and map ones are covered by the conformance vectors, and the tier fix from #14 stays in the tree.
- `sizeOfPackedString` — correct, since a string's length is its byte count.
- The scalar helpers (`getIntSize`, `getFloatSize`, `getEnumSize`, `getBoolSize`, `getNullSize`, and the `getMax*` variants) — all correct.

Also drops two imports in `any.zig` that this leaves orphaned, plus the `headers.zig` import there, which had no `hdrs.` reference even before this change.

## Note on sizing

Nothing in the encoder ever used any of this — it writes directly and never pre-computes a length, so the family only ever called itself. Anyone who needs an encoded size should encode into a counting writer, which reuses the real encoder and cannot drift from it. Predicting sizes with a parallel implementation is what produced this bug in the first place.

`zig build test`: 147/147 pass (six tests removed with the code they covered). `zig fmt --check` clean.
