### PR TITLE
feat: add skip_unknown_fields for forward-compatible decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `skip_unknown_fields` option on `StructAsMapOptions` and `UnionAsTaggedOptions`, to step over map entries with no matching field instead of failing with `error.UnknownStructField`; off by default
+- `skipAny`, which discards one complete msgpack value of any type from a reader
+
 ### Removed
 - `sizeOfPackedArray` and `sizeOfPackedMap`, which under-reported sizes by adding the element count to the header size; the `sizeOfPackedArrayHeader` and `sizeOfPackedMapHeader` variants are correct and remain
 - `Packer.getArrayHeaderSize` and `Packer.getMapHeaderSize`; call `sizeOfPackedArrayHeader` and `sizeOfPackedMapHeader` directly

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ const Message = struct {
 };
 ```
 
-Both options have the disadvantage that changing the fields in the struct will have impact on the encoded message, so you need to be careful about backwarads compatibility.
-You can also use custom protobuf-like field keys to ensure full compatibility even after changing the struct:
+Both options have the disadvantage that changing the fields in the struct will have impact on the encoded message, so you need to be careful about backwards compatibility.
+You can also use custom protobuf-like field keys, so that renaming or reordering fields does not change the encoded message:
 
 ```zig
 const std = @import("std");
@@ -111,6 +111,31 @@ const Message = struct {
     }
 };
 ```
+
+Stable keys alone are not enough to read messages from a *newer* encoder, though: by default a key
+that matches no field is an error. Set `skip_unknown_fields` to step over those entries instead, so
+adding a field on the producer does not break existing consumers:
+
+```zig
+const Message = struct {
+    name: []const u8,
+    age: u8,
+
+    pub fn msgpackFormat() msgpack.StructFormat {
+        return .{ .as_map = .{ .key = .custom, .skip_unknown_fields = true } };
+    }
+
+    pub fn msgpackFieldKey(field: std.meta.FieldEnum(@This())) u8 {
+        return switch (field) {
+            .name => 1,
+            .age => 2,
+        };
+    }
+};
+```
+
+It works with every key mode, and with `.as_tagged` unions. Missing fields are already accepted
+without any option, as long as they have a default value or are optional.
 
 Or you can use a completely custom format:
 

--- a/src/msgpack.zig
+++ b/src/msgpack.zig
@@ -69,6 +69,8 @@ pub const getMaxEnumSize = @import("enum.zig").getMaxEnumSize;
 pub const packEnum = @import("enum.zig").packEnum;
 pub const unpackEnum = @import("enum.zig").unpackEnum;
 
+pub const skipAny = @import("skip.zig").skipAny;
+
 pub const packAny = @import("any.zig").packAny;
 pub const unpackAny = @import("any.zig").unpackAny;
 
@@ -514,7 +516,7 @@ test "custom msgpackWrite/msgpackRead using writeArray and readArray" {
 
     try std.testing.expectEqualSlices(u32, &items, decoded.value.items);
 }
-    
+
 test "unpacker readUnion" {
     // `refAllDecls` does not instantiate generic functions, so a signature
     // mismatch here stays invisible until something actually calls it.

--- a/src/skip.zig
+++ b/src/skip.zig
@@ -1,0 +1,200 @@
+const std = @import("std");
+const hdrs = @import("headers.zig");
+
+const takeInt = @import("utils.zig").takeInt;
+
+/// Discards exactly one complete msgpack value from the reader, however deeply
+/// nested, without materialising any of it. Used to step over map entries a
+/// struct has no field for.
+///
+/// Iterative rather than recursive: a container adds its children to a running
+/// count instead of nesting a call, so deeply nested input costs no stack. The
+/// count saturates, and any value large enough to matter runs the reader out of
+/// bytes long before it could wrap.
+pub fn skipAny(reader: *std.Io.Reader) !void {
+    var remaining: u64 = 1;
+    while (remaining > 0) {
+        remaining -= 1;
+        const header = try reader.takeByte();
+        switch (header) {
+            // Values carried entirely in the header byte.
+            hdrs.POSITIVE_FIXINT_MIN...hdrs.POSITIVE_FIXINT_MAX,
+            hdrs.NEGATIVE_FIXINT_MIN...hdrs.NEGATIVE_FIXINT_MAX,
+            hdrs.NIL,
+            hdrs.FALSE,
+            hdrs.TRUE,
+            => {},
+
+            // Fixed-width payloads.
+            hdrs.UINT8, hdrs.INT8 => try reader.discardAll(1),
+            hdrs.UINT16, hdrs.INT16 => try reader.discardAll(2),
+            hdrs.UINT32, hdrs.INT32, hdrs.FLOAT32 => try reader.discardAll(4),
+            hdrs.UINT64, hdrs.INT64, hdrs.FLOAT64 => try reader.discardAll(8),
+
+            // Length-prefixed byte payloads.
+            hdrs.FIXSTR_MIN...hdrs.FIXSTR_MAX => try reader.discardAll(header - hdrs.FIXSTR_MIN),
+            hdrs.STR8, hdrs.BIN8 => try reader.discardAll(try takeInt(reader, u8)),
+            hdrs.STR16, hdrs.BIN16 => try reader.discardAll(try takeInt(reader, u16)),
+            hdrs.STR32, hdrs.BIN32 => try reader.discardAll64(try takeInt(reader, u32)),
+
+            // Extension types: a one-byte type tag followed by the payload.
+            hdrs.FIXEXT1 => try reader.discardAll(1 + 1),
+            hdrs.FIXEXT2 => try reader.discardAll(1 + 2),
+            hdrs.FIXEXT4 => try reader.discardAll(1 + 4),
+            hdrs.FIXEXT8 => try reader.discardAll(1 + 8),
+            hdrs.FIXEXT16 => try reader.discardAll(1 + 16),
+            hdrs.EXT8 => try reader.discardAll(1 + @as(usize, try takeInt(reader, u8))),
+            hdrs.EXT16 => try reader.discardAll(1 + @as(usize, try takeInt(reader, u16))),
+            hdrs.EXT32 => try reader.discardAll64(1 + @as(u64, try takeInt(reader, u32))),
+
+            // Containers: queue the child values instead of recursing.
+            hdrs.FIXARRAY_MIN...hdrs.FIXARRAY_MAX => remaining +|= header - hdrs.FIXARRAY_MIN,
+            hdrs.ARRAY16 => remaining +|= try takeInt(reader, u16),
+            hdrs.ARRAY32 => remaining +|= try takeInt(reader, u32),
+            hdrs.FIXMAP_MIN...hdrs.FIXMAP_MAX => remaining +|= 2 * @as(u64, header - hdrs.FIXMAP_MIN),
+            hdrs.MAP16 => remaining +|= 2 * @as(u64, try takeInt(reader, u16)),
+            hdrs.MAP32 => remaining +|= 2 * @as(u64, try takeInt(reader, u32)),
+
+            // 0xc1 is not assigned by the msgpack spec.
+            else => return error.InvalidFormat,
+        }
+    }
+}
+
+test "skipAny: values carried in the header byte" {
+    for ([_][]const u8{
+        &[_]u8{0x00}, // positive fixint 0
+        &[_]u8{0x7f}, // positive fixint 127
+        &[_]u8{0xe0}, // negative fixint -32
+        &[_]u8{0xff}, // negative fixint -1
+        &[_]u8{0xc0}, // nil
+        &[_]u8{0xc2}, // false
+        &[_]u8{0xc3}, // true
+    }) |encoding| {
+        var reader = std.Io.Reader.fixed(encoding);
+        try skipAny(&reader);
+        try std.testing.expectEqual(0, reader.bufferedLen());
+    }
+}
+
+test "skipAny: fixed-width payloads" {
+    for ([_][]const u8{
+        &[_]u8{ 0xcc, 0x01 }, // uint8
+        &[_]u8{ 0xd0, 0x01 }, // int8
+        &[_]u8{ 0xcd, 0x01, 0x02 }, // uint16
+        &[_]u8{ 0xd1, 0x01, 0x02 }, // int16
+        &[_]u8{ 0xce, 0x01, 0x02, 0x03, 0x04 }, // uint32
+        &[_]u8{ 0xca, 0x40, 0x49, 0x0f, 0xdb }, // float32
+        &[_]u8{ 0xcf, 1, 2, 3, 4, 5, 6, 7, 8 }, // uint64
+        &[_]u8{ 0xcb, 1, 2, 3, 4, 5, 6, 7, 8 }, // float64
+    }) |encoding| {
+        var reader = std.Io.Reader.fixed(encoding);
+        try skipAny(&reader);
+        try std.testing.expectEqual(0, reader.bufferedLen());
+    }
+}
+
+test "skipAny: length-prefixed payloads" {
+    for ([_][]const u8{
+        &[_]u8{ 0xa3, 'a', 'b', 'c' }, // fixstr
+        &[_]u8{ 0xd9, 0x03, 'a', 'b', 'c' }, // str8
+        &[_]u8{ 0xda, 0x00, 0x03, 'a', 'b', 'c' }, // str16
+        &[_]u8{ 0xdb, 0x00, 0x00, 0x00, 0x03, 'a', 'b', 'c' }, // str32
+        &[_]u8{ 0xc4, 0x03, 1, 2, 3 }, // bin8
+        &[_]u8{ 0xc5, 0x00, 0x03, 1, 2, 3 }, // bin16
+        &[_]u8{ 0xc6, 0x00, 0x00, 0x00, 0x03, 1, 2, 3 }, // bin32
+    }) |encoding| {
+        var reader = std.Io.Reader.fixed(encoding);
+        try skipAny(&reader);
+        try std.testing.expectEqual(0, reader.bufferedLen());
+    }
+}
+
+test "skipAny: extension types" {
+    for ([_][]const u8{
+        &[_]u8{ 0xd4, 0x01, 0xff }, // fixext1
+        &[_]u8{ 0xd5, 0x01, 0xff, 0xff }, // fixext2
+        &[_]u8{ 0xd6, 0x01, 1, 2, 3, 4 }, // fixext4
+        &[_]u8{ 0xd7, 0x01, 1, 2, 3, 4, 5, 6, 7, 8 }, // fixext8
+        &[_]u8{ 0xd8, 0x01 } ++ &[_]u8{0xab} ** 16, // fixext16
+        &[_]u8{ 0xc7, 0x03, 0x01, 1, 2, 3 }, // ext8
+        &[_]u8{ 0xc8, 0x00, 0x03, 0x01, 1, 2, 3 }, // ext16
+        &[_]u8{ 0xc9, 0x00, 0x00, 0x00, 0x03, 0x01, 1, 2, 3 }, // ext32
+    }) |encoding| {
+        var reader = std.Io.Reader.fixed(encoding);
+        try skipAny(&reader);
+        try std.testing.expectEqual(0, reader.bufferedLen());
+    }
+}
+
+test "skipAny: containers" {
+    for ([_][]const u8{
+        &[_]u8{0x90}, // empty fixarray
+        &[_]u8{ 0x93, 0x01, 0x02, 0x03 }, // fixarray of 3
+        &[_]u8{ 0xdc, 0x00, 0x02, 0x01, 0x02 }, // array16 of 2
+        &[_]u8{ 0xdd, 0x00, 0x00, 0x00, 0x02, 0x01, 0x02 }, // array32 of 2
+        &[_]u8{0x80}, // empty fixmap
+        &[_]u8{ 0x81, 0xa1, 'a', 0x01 }, // fixmap of 1
+        &[_]u8{ 0xde, 0x00, 0x01, 0xa1, 'a', 0x01 }, // map16 of 1
+        &[_]u8{ 0xdf, 0x00, 0x00, 0x00, 0x01, 0xa1, 'a', 0x01 }, // map32 of 1
+    }) |encoding| {
+        var reader = std.Io.Reader.fixed(encoding);
+        try skipAny(&reader);
+        try std.testing.expectEqual(0, reader.bufferedLen());
+    }
+}
+
+test "skipAny: nested containers" {
+    // {"a": [1, {"b": [2, 3]}], "c": nil}
+    const encoding = [_]u8{
+        0x82, // map of 2
+        0xa1, 'a', // key "a"
+        0x92, // array of 2
+        0x01, // 1
+        0x81, // map of 1
+        0xa1, 'b', // key "b"
+        0x92, 0x02, 0x03, // [2, 3]
+        0xa1, 'c', // key "c"
+        0xc0, // nil
+    };
+    var reader = std.Io.Reader.fixed(&encoding);
+    try skipAny(&reader);
+    try std.testing.expectEqual(0, reader.bufferedLen());
+}
+
+test "skipAny: stops at the end of one value, leaving the rest" {
+    const encoding = [_]u8{ 0x93, 0x01, 0x02, 0x03, 0xc3 }; // [1,2,3] then true
+    var reader = std.Io.Reader.fixed(&encoding);
+    try skipAny(&reader);
+    try std.testing.expectEqualSlices(u8, &[_]u8{0xc3}, reader.buffered());
+}
+
+test "skipAny: truncated input reports end of stream" {
+    for ([_][]const u8{
+        &[_]u8{}, // nothing at all
+        &[_]u8{0xcc}, // uint8 with no payload
+        &[_]u8{ 0xa3, 'a' }, // fixstr claiming 3 bytes, only 1 present
+        &[_]u8{ 0x93, 0x01 }, // array of 3 with only 1 element
+        &[_]u8{ 0x81, 0xa1, 'a' }, // map entry missing its value
+    }) |encoding| {
+        var reader = std.Io.Reader.fixed(encoding);
+        try std.testing.expectError(error.EndOfStream, skipAny(&reader));
+    }
+}
+
+test "skipAny: unassigned header byte is rejected" {
+    const encoding = [_]u8{0xc1};
+    var reader = std.Io.Reader.fixed(&encoding);
+    try std.testing.expectError(error.InvalidFormat, skipAny(&reader));
+}
+
+test "skipAny: deep nesting does not grow the stack" {
+    // 10k nested single-element arrays, then a nil at the bottom.
+    var encoding: [10_001]u8 = undefined;
+    @memset(encoding[0..10_000], 0x91);
+    encoding[10_000] = 0xc0;
+
+    var reader = std.Io.Reader.fixed(&encoding);
+    try skipAny(&reader);
+    try std.testing.expectEqual(0, reader.bufferedLen());
+}

--- a/src/struct.zig
+++ b/src/struct.zig
@@ -23,6 +23,8 @@ const eqlLiteral = @import("utils.zig").eqlLiteral;
 const packArrayHeader = @import("array.zig").packArrayHeader;
 const unpackArrayHeader = @import("array.zig").unpackArrayHeader;
 
+const skipAny = @import("skip.zig").skipAny;
+
 const packAny = @import("any.zig").packAny;
 const unpackAny = @import("any.zig").unpackAny;
 
@@ -38,6 +40,11 @@ pub const StructAsMapOptions = struct {
     },
     omit_nulls: bool = true,
     omit_defaults: bool = false,
+    /// Step over map entries whose key matches no field, instead of failing
+    /// with `error.UnknownStructField`. Lets a decoder read messages from a
+    /// newer encoder that added fields. Missing fields are already tolerated
+    /// unconditionally, via defaults and optionals.
+    skip_unknown_fields: bool = false,
 };
 
 pub const StructAsArrayOptions = struct {};
@@ -179,7 +186,8 @@ pub fn unpackStructFromMapBody(reader: *std.Io.Reader, allocator: std.mem.Alloca
                         break;
                     }
                 } else {
-                    return error.UnknownStructField;
+                    if (!opts.skip_unknown_fields) return error.UnknownStructField;
+                    try skipAny(reader);
                 }
             },
             .field_name => {
@@ -191,7 +199,8 @@ pub fn unpackStructFromMapBody(reader: *std.Io.Reader, allocator: std.mem.Alloca
                         break;
                     }
                 } else {
-                    return error.UnknownStructField;
+                    if (!opts.skip_unknown_fields) return error.UnknownStructField;
+                    try skipAny(reader);
                 }
             },
             .field_name_prefix => |prefix| {
@@ -203,7 +212,8 @@ pub fn unpackStructFromMapBody(reader: *std.Io.Reader, allocator: std.mem.Alloca
                         break;
                     }
                 } else {
-                    return error.UnknownStructField;
+                    if (!opts.skip_unknown_fields) return error.UnknownStructField;
+                    try skipAny(reader);
                 }
             },
             .custom => {
@@ -216,7 +226,8 @@ pub fn unpackStructFromMapBody(reader: *std.Io.Reader, allocator: std.mem.Alloca
                         break;
                     }
                 } else {
-                    return error.UnknownStructField;
+                    if (!opts.skip_unknown_fields) return error.UnknownStructField;
+                    try skipAny(reader);
                 }
             },
         }
@@ -711,4 +722,160 @@ test "readStruct: msgpackFieldKey" {
     var reader = std.Io.Reader.fixed(&buffer);
     const value = try unpackStruct(&reader, NoAllocator.allocator(), Msg);
     try std.testing.expectEqual(Msg{ .a = 1, .b = 2 }, value);
+}
+
+test "readStruct: unknown fields are rejected by default" {
+    const Msg = struct { a: u32 };
+
+    const buffer = [_]u8{
+        0x82, // map with 2 entries
+        0xa1, 'a', 0x01, // "a": 1
+        0xa1, 'z', 0x02, // "z": 2, no such field
+    };
+    var reader = std.Io.Reader.fixed(&buffer);
+    try std.testing.expectError(
+        error.UnknownStructField,
+        unpackStruct(&reader, NoAllocator.allocator(), Msg),
+    );
+}
+
+test "readStruct: skip_unknown_fields steps over entries with no matching field" {
+    const Msg = struct {
+        a: u32,
+        b: u32,
+
+        pub fn msgpackFormat() StructFormat {
+            return .{ .as_map = .{ .key = .field_name, .skip_unknown_fields = true } };
+        }
+    };
+
+    const buffer = [_]u8{
+        0x84, // map with 4 entries
+        0xa1, 'z', 0xc0, // "z": nil, before any known field
+        0xa1, 'a', 0x01, // "a": 1
+        0xa1, 'y', 0x93, 0x01, 0x02, 0x03, // "y": [1,2,3], a container
+        0xa1, 'b', 0x02, // "b": 2
+    };
+    var reader = std.Io.Reader.fixed(&buffer);
+    const value = try unpackStruct(&reader, NoAllocator.allocator(), Msg);
+    try std.testing.expectEqual(1, value.a);
+    try std.testing.expectEqual(2, value.b);
+}
+
+test "readStruct: skip_unknown_fields with a deeply nested unknown value" {
+    const Msg = struct {
+        a: u32,
+
+        pub fn msgpackFormat() StructFormat {
+            return .{ .as_map = .{ .key = .field_name, .skip_unknown_fields = true } };
+        }
+    };
+
+    const buffer = [_]u8{
+        0x82, // map with 2 entries
+        0xa1, 'z', // "z":
+        0x82, //   map with 2 entries
+        0xa1, 'p', 0x92, 0x01, 0x81, 0xa1, 'q', 0xc3, //     "p": [1, {"q": true}]
+        0xa1, 'r', 0xa2, 'h', 'i', //     "r": "hi"
+        0xa1, 'a', 0x07, // "a": 7
+    };
+    var reader = std.Io.Reader.fixed(&buffer);
+    const value = try unpackStruct(&reader, NoAllocator.allocator(), Msg);
+    try std.testing.expectEqual(7, value.a);
+}
+
+test "readStruct: skip_unknown_fields by field index" {
+    const Msg = struct {
+        a: u32,
+        b: u32,
+
+        pub fn msgpackFormat() StructFormat {
+            return .{ .as_map = .{ .key = .field_index, .skip_unknown_fields = true } };
+        }
+    };
+
+    const buffer = [_]u8{
+        0x83, // map with 3 entries
+        0x00, 0x01, // 0: 1
+        0x02, 0xc3, // 2: true, no field at that index
+        0x01, 0x02, // 1: 2
+    };
+    var reader = std.Io.Reader.fixed(&buffer);
+    const value = try unpackStruct(&reader, NoAllocator.allocator(), Msg);
+    try std.testing.expectEqual(1, value.a);
+    try std.testing.expectEqual(2, value.b);
+}
+
+test "readStruct: skip_unknown_fields with custom field keys" {
+    const Msg = struct {
+        a: u32,
+
+        pub fn msgpackFormat() StructFormat {
+            return .{ .as_map = .{ .key = .custom, .skip_unknown_fields = true } };
+        }
+
+        pub fn msgpackFieldKey(field: std.meta.FieldEnum(@This())) u8 {
+            return switch (field) {
+                .a => 1,
+            };
+        }
+    };
+
+    const buffer = [_]u8{
+        0x82, // map with 2 entries
+        0x09, 0xa3, 'o', 'l', 'd', // 9: "old", retired field number
+        0x01, 0x05, // 1: 5
+    };
+    var reader = std.Io.Reader.fixed(&buffer);
+    const value = try unpackStruct(&reader, NoAllocator.allocator(), Msg);
+    try std.testing.expectEqual(5, value.a);
+}
+
+test "readStruct: a newer encoder's message decodes into an older struct" {
+    const V2 = struct {
+        id: u32,
+        name: []const u8,
+        added_later: bool,
+    };
+    const V1 = struct {
+        id: u32,
+        name: []const u8,
+
+        pub fn msgpackFormat() StructFormat {
+            return .{ .as_map = .{ .key = .field_name, .skip_unknown_fields = true } };
+        }
+    };
+
+    var aw: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer aw.deinit();
+    try packStruct(&aw.writer, V2, .{ .id = 42, .name = "hello", .added_later = true });
+
+    var reader = std.Io.Reader.fixed(aw.written());
+    const value = try unpackStruct(&reader, std.testing.allocator, V1);
+    defer std.testing.allocator.free(value.name);
+
+    try std.testing.expectEqual(42, value.id);
+    try std.testing.expectEqualStrings("hello", value.name);
+}
+
+test "readStruct: skipping an unknown field does not satisfy a missing one" {
+    const Msg = struct {
+        a: u32,
+        b: u32,
+
+        pub fn msgpackFormat() StructFormat {
+            return .{ .as_map = .{ .key = .field_name, .skip_unknown_fields = true } };
+        }
+    };
+
+    const buffer = [_]u8{
+        0x82, // map with 2 entries
+        0xa1, 'a', 0x01, // "a": 1
+        0xa1, 'z', 0x02, // "z": 2, skipped, so b is still absent
+    };
+    var reader = std.Io.Reader.fixed(&buffer);
+    try std.testing.expectError(
+        error.MissingStructFields,
+        unpackStruct(&reader, NoAllocator.allocator(), Msg),
+    );
 }

--- a/src/union.zig
+++ b/src/union.zig
@@ -46,6 +46,10 @@ pub const UnionAsTaggedOptions = struct {
         field_name_prefix: u8,
         field_index,
     } = .field_name,
+    /// Step over entries in the flattened map that match neither the tag field
+    /// nor a field of the selected variant. See
+    /// `StructAsMapOptions.skip_unknown_fields`.
+    skip_unknown_fields: bool = false,
 };
 
 pub const UnionFormat = union(enum) {
@@ -262,7 +266,10 @@ pub fn unpackUnionAsTagged(reader: *std.Io.Reader, allocator: std.mem.Allocator,
                 }
                 return @unionInit(Type, field.name, {});
             } else if (field_type_info == .@"struct") {
-                const struct_opts = StructAsMapOptions{ .key = .field_name };
+                const struct_opts = StructAsMapOptions{
+                    .key = .field_name,
+                    .skip_unknown_fields = opts.skip_unknown_fields,
+                };
                 const struct_value = try unpackStructFromMapBody(reader, allocator, field.type, len - 1, struct_opts);
                 return @unionInit(Type, field.name, struct_value);
             } else {
@@ -475,4 +482,71 @@ test "readUnion: tagged format with field index" {
     var reader = std.Io.Reader.fixed(&msg4_get_packed);
     const value = try unpackUnion(&reader, NoAllocator.allocator(), Msg4);
     try std.testing.expectEqual(99, value.get.key);
+}
+
+test "readUnion: as_tagged rejects unknown variant fields by default" {
+    const Msg = union(enum) {
+        get: struct { key: u32 },
+
+        pub fn msgpackFormat() UnionFormat {
+            return .{ .as_tagged = .{} };
+        }
+    };
+
+    const buffer = [_]u8{
+        0x83, // map with 3 entries
+        0xa4, 't', 'y', 'p', 'e', 0xa3, 'g', 'e', 't', // "type": "get"
+        0xa3, 'k', 'e', 'y', 0x2a, // "key": 42
+        0xa1, 'z', 0xc3, // "z": true, not a field of `get`
+    };
+    var reader = std.Io.Reader.fixed(&buffer);
+    try std.testing.expectError(
+        error.UnknownStructField,
+        unpackUnion(&reader, NoAllocator.allocator(), Msg),
+    );
+}
+
+test "readUnion: as_tagged skip_unknown_fields steps over extra variant fields" {
+    const Msg = union(enum) {
+        get: struct { key: u32 },
+        put: struct { key: u32, val: u64 },
+
+        pub fn msgpackFormat() UnionFormat {
+            return .{ .as_tagged = .{ .skip_unknown_fields = true } };
+        }
+    };
+
+    // A newer producer added a field to the `get` variant.
+    const buffer = [_]u8{
+        0x84, // map with 4 entries
+        0xa4, 't', 'y', 'p', 'e', 0xa3, 'g', 'e', 't', // "type": "get"
+        0xa1, 'z', 0x92, 0x01, 0x02, // "z": [1,2], unknown, a container
+        0xa3, 'k', 'e', 'y', 0x2a, // "key": 42
+        0xa1, 'w', 0xc0, // "w": nil, unknown
+    };
+    var reader = std.Io.Reader.fixed(&buffer);
+    const value = try unpackUnion(&reader, NoAllocator.allocator(), Msg);
+    try std.testing.expectEqual(@as(u32, 42), value.get.key);
+}
+
+test "readUnion: as_tagged skip_unknown_fields still requires the variant's own fields" {
+    const Msg = union(enum) {
+        put: struct { key: u32, val: u64 },
+
+        pub fn msgpackFormat() UnionFormat {
+            return .{ .as_tagged = .{ .skip_unknown_fields = true } };
+        }
+    };
+
+    const buffer = [_]u8{
+        0x83, // map with 3 entries
+        0xa4, 't', 'y', 'p', 'e', 0xa3, 'p', 'u', 't', // "type": "put"
+        0xa3, 'k', 'e', 'y', 0x2a, // "key": 42
+        0xa1, 'z', 0xc3, // "z": true, skipped; `val` never arrives
+    };
+    var reader = std.Io.Reader.fixed(&buffer);
+    try std.testing.expectError(
+        error.MissingStructFields,
+        unpackUnion(&reader, NoAllocator.allocator(), Msg),
+    );
 }


### PR DESCRIPTION
Fixes #24.

A map key matching no struct field was always `error.UnknownStructField`, so a decoder could not read a message from a newer encoder that added a field. That sat oddly beside the decoder's treatment of *missing* fields, which are accepted unconditionally when they have a default or are optional — extra fields fatal with no opt-in, missing fields free with no opt-out.

## The option

```zig
pub fn msgpackFormat() msgpack.StructFormat {
    return .{ .as_map = .{ .key = .custom, .skip_unknown_fields = true } };
}
```

It sits on `StructAsMapOptions` next to `omit_nulls` and `omit_defaults`, which are also per-direction policy rather than wire format — those two are encode-side and ignored by the decoder, this one is decode-side. **Defaults to `false`, so existing behaviour is unchanged.**

Works with all four key modes (`field_name`, `field_name_prefix`, `field_index`, `custom`).

## skipAny

Skipping requires discarding one complete value of arbitrary type, which nothing here could do. `skipAny` handles every msgpack type — including `ext`/`fixext`, which nothing else in the library parses — and rejects the unassigned `0xc1`.

It is **iterative, not recursive**: a container adds its children to a running count rather than nesting a call, so deeply nested input costs no stack. There's a test that skips 10,000 nested arrays.

It's exported rather than kept internal. It's useful on its own, but there's a second reason: `opts` is comptime, so with the flag off the `try skipAny(reader)` call site folds away entirely, and the function would never be analysed — not compiled, not type-checked, not tested. That's exactly how `sizeOfPackedAny` rotted for 17 months (#23) and how #21/#22 hid. Exporting it puts it under `refAllDecls` and pulls its tests into the run; the test count goes from 144 to 154 purely from that.

## Tagged unions

`as_tagged` flattens the variant's fields into the same map, and `unpackUnionAsTagged` was building `StructAsMapOptions{ .key = .field_name }` from scratch for the body. `UnionAsTaggedOptions` grows the same flag and passes it down.

## README

The README claimed custom field keys "ensure full compatibility even after changing the struct". They keep the encoding stable across renames and reordering, but reading a newer producer's message needs this option too — that sentence is corrected, and the new option documented. (Also fixes a "backwarads" typo on the line above.)

## Tests

164 pass, up from 147. Covers each key mode, unknown values that are containers and deeply nested maps, a V2-encodes/V1-decodes round trip, both tagged-union directions, and that skipping an unknown field does **not** satisfy a genuinely missing one — `error.MissingStructFields` still fires. Plus 10 tests for `skipAny` itself across every type family, truncation, and the unassigned header byte.

## Not included

`UnionAsMapOptions.omit_nulls` and `.omit_defaults` are dead — declared, never read in either direction, and meaningless there since a union-as-map always writes exactly one entry. Left out to keep this focused; happy to remove them separately.
