### PR TITLE
docs: record the unreleased changes in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `skip_unknown_fields` option on `StructAsMapOptions` and `UnionAsTaggedOptions`, to step over map entries with no matching field instead of failing with `error.UnknownStructField`; off by default
 - `skipAny`, which discards one complete msgpack value of any type from a reader
 
+### Changed
+- Faster encoding and decoding of fixed-size values, and of struct map keys, by avoiding intermediate copies
+
 ### Removed
 - `sizeOfPackedArray` and `sizeOfPackedMap`, which under-reported sizes by adding the element count to the header size; the `sizeOfPackedArrayHeader` and `sizeOfPackedMapHeader` variants are correct and remain
 - `Packer.getArrayHeaderSize` and `Packer.getMapHeaderSize`; call `sizeOfPackedArrayHeader` and `sizeOfPackedMapHeader` directly
+
+### Fixed
+- `Unpacker.readArray` could not be instantiated with any type; it now takes the element type, like `Packer.writeArray` and `Unpacker.readArrayInto`, so the custom format example in the README compiles
+- `Unpacker.readUnion` returned `!?T` while `unpackUnion` returns `!T`, so it could not be instantiated
 
 ## [0.7.0] - 2026-04-30
 


### PR DESCRIPTION
Three sets of changes since v0.7.0 were missing from `[Unreleased]`.

**Never recorded at all:** #18 and #19, the encode and decode fast paths. They landed right after the v0.7.0 tag and were the only entries with no changelog line.

**From this batch:** #25 and #26, the two `Unpacker` signature fixes.

#27 and #28 were already recorded. Sections reordered to Keep a Changelog's order (Added, Changed, Removed, Fixed).
