### PR TITLE
docs: document the Leaky decode API

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,20 +41,35 @@ const Message = struct {
     age: u8,
 };
 
-var buffer = std.ArrayList(u8).init(allocator);
+var buffer: std.Io.Writer.Allocating = .init(allocator);
 defer buffer.deinit();
 
 try msgpack.encode(Message{
     .name = "John",
     .age = 20,
-}, buffer.writer());
+}, &buffer.writer);
 
-const decoded = try msgpack.decodeFromSlice(Message, allocator, buffer.items);
+const decoded = try msgpack.decodeFromSlice(Message, allocator, buffer.written());
 defer decoded.deinit();
 
 std.debug.assert(std.mem.eql(u8, decoded.value.name, "John"));
 std.debug.assert(decoded.value.age == 20);
 ```
+
+`decodeFromSlice` creates an arena of its own for the decoded value, which is what `deinit` frees.
+If you are already decoding into memory you release in one go — a per-request arena, or a fixed
+buffer — use `decodeFromSliceLeaky` instead. It allocates straight from the allocator you give it,
+so there is nothing to deinit, and it avoids a second arena inside your own:
+
+```zig
+var arena = std.heap.ArenaAllocator.init(allocator);
+defer arena.deinit();
+
+const message = try msgpack.decodeFromSliceLeaky(Message, arena.allocator(), buffer.written());
+```
+
+`decodeLeaky` is the same for a reader. In a loop, reuse one arena and `reset(.retain_capacity)`
+between messages; the arena then stops going back to its backing allocator entirely.
 
 The encoded message will use field names as keys to encode the message. In order to generate more compact messages, you can change the format to use field indexes:
 


### PR DESCRIPTION
The README only ever showed `decodeFromSlice`, so nothing pointed a reader at `decodeFromSliceLeaky` or said when it is the right choice. That is the likely reason the GLD serializer benchmark called `decodeFromSlice` inside a loop that already had a per-trial arena, paying for a second arena on every call — a 30–45% decode cost in that harness.

`std.json` avoids the same trap with one line in the doc comment on `parseFromSlice`. This adds the equivalent: four sentences and a snippet, after the basic example.

## Also fixes the basic example

It had not been updated for the `std.Io` writer API and did not compile:

```zig
var buffer = std.ArrayList(u8).init(allocator);   // no such init in 0.16
try msgpack.encode(..., buffer.writer());         // ArrayList has no writer()
```

`std.ArrayList` has no `writer()` in Zig 0.16, and `encode` takes a `*std.Io.Writer`. Now uses `std.Io.Writer.Allocating`, matching the library's own tests.

Both snippets were compiled and run against the library before committing, rather than eyeballed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated usage examples for the current Zig I/O writer API.
  * Added guidance for arena-backed decoding, including leaky decoding methods and arena reuse.
  * Revised encoding and decoding examples to reflect current buffer handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->