### PR TITLE
perf: decode optionals through the leaf unpackers

### DIFF
--- a/src/any.zig
+++ b/src/any.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 
+const NonOptional = @import("utils.zig").NonOptional;
+
 const packNull = @import("null.zig").packNull;
 const unpackNull = @import("null.zig").unpackNull;
 
@@ -13,7 +15,7 @@ const packFloat = @import("float.zig").packFloat;
 const unpackFloat = @import("float.zig").unpackFloat;
 
 const packString = @import("string.zig").packString;
-const unpackString = @import("string.zig").unpackString;
+const unpackStringValue = @import("string.zig").unpackStringValue;
 const String = @import("string.zig").String;
 const Binary = @import("binary.zig").Binary;
 
@@ -94,8 +96,13 @@ pub fn packAny(writer: *std.Io.Writer, value: anytype) !void {
     @compileError("Unsupported type '" ++ @typeName(T) ++ "'");
 }
 
+/// Every `unpack*` below accepts an optional type and decodes a nil header to
+/// null as one more case of the header switch it already performs. So dispatch
+/// on the shape underneath the optional and pass `T` through untouched, rather
+/// than testing for nil here and stripping it — that would read the header
+/// twice and leave each leaf's own nil handling unused.
 pub fn unpackAny(reader: *std.Io.Reader, allocator: std.mem.Allocator, comptime T: type) !T {
-    switch (@typeInfo(T)) {
+    switch (@typeInfo(NonOptional(T))) {
         .void => return unpackNull(reader),
         .bool => return unpackBool(reader, T),
         .int => return unpackInt(reader, T),
@@ -106,17 +113,11 @@ pub fn unpackAny(reader: *std.Io.Reader, allocator: std.mem.Allocator, comptime 
         .pointer => |ptr_info| {
             if (ptr_info.size == .slice) {
                 if (isString(T)) {
-                    return unpackString(reader, allocator);
+                    return unpackStringValue(reader, allocator, T);
                 } else {
                     return unpackArray(reader, allocator, T);
                 }
             }
-        },
-        .optional => |opt_info| {
-            unpackNull(reader) catch {
-                return try unpackAny(reader, allocator, opt_info.child);
-            };
-            return null;
         },
         else => {},
     }
@@ -346,4 +347,36 @@ test "packAny/unpackAny: Binary struct" {
     const result = try unpackAny(&reader, std.testing.allocator, Binary);
     defer std.testing.allocator.free(result.data);
     try std.testing.expectEqualSlices(u8, "\x01\x02\x03\x04", result.data);
+}
+
+test "unpackAny: optional dispatches to the leaf without disturbing the stream" {
+    // The optional is handed to the leaf unpacker intact, so a present value
+    // must consume exactly its own bytes and leave the next value readable.
+    const buffer = [_]u8{ 0x2a, 0xc3 }; // 42, then true
+    var reader = std.Io.Reader.fixed(&buffer);
+    try std.testing.expectEqual(@as(?u8, 42), try unpackAny(&reader, std.testing.allocator, ?u8));
+    try std.testing.expectEqual(true, try unpackAny(&reader, std.testing.allocator, bool));
+}
+
+test "unpackAny: optional string reads nil as null" {
+    const packed_nil = [_]u8{0xc0};
+    var reader = std.Io.Reader.fixed(&packed_nil);
+    const value = try unpackAny(&reader, std.testing.allocator, ?[]const u8);
+    try std.testing.expectEqual(@as(?[]const u8, null), value);
+}
+
+test "unpackAny: optional string reads a value" {
+    const packed_abc = [_]u8{ 0xa3, 'a', 'b', 'c' };
+    var reader = std.Io.Reader.fixed(&packed_abc);
+    const value = try unpackAny(&reader, std.testing.allocator, ?[]const u8);
+    defer if (value) |v| std.testing.allocator.free(v);
+    try std.testing.expectEqualStrings("abc", value.?);
+}
+
+test "unpackAny: a non-optional receiving nil still errors" {
+    const packed_nil = [_]u8{0xc0};
+    inline for (.{ u32, bool, f64 }) |T| {
+        var reader = std.Io.Reader.fixed(&packed_nil);
+        try std.testing.expectError(error.Null, unpackAny(&reader, std.testing.allocator, T));
+    }
 }

--- a/src/null.zig
+++ b/src/null.zig
@@ -12,13 +12,18 @@ pub fn packNull(writer: *std.Io.Writer) !void {
     try writer.writeByte(hdrs.NIL);
 }
 
-pub fn unpackNull(reader: *std.Io.Reader) !void {
-    const header = try reader.peekByte();
-    if (header == hdrs.NIL) {
+/// Consumes a nil header if the next value is one, reporting whether it did and
+/// leaving the reader untouched otherwise.
+pub fn unpackNullIfPresent(reader: *std.Io.Reader) !bool {
+    if (try reader.peekByte() == hdrs.NIL) {
         reader.toss(1);
-        return;
+        return true;
     }
-    return error.InvalidFormat;
+    return false;
+}
+
+pub fn unpackNull(reader: *std.Io.Reader) !void {
+    if (!try unpackNullIfPresent(reader)) return error.InvalidFormat;
 }
 
 pub fn maybePackNull(writer: *std.Io.Writer, comptime T: type, value: T) !?NonOptional(T) {

--- a/src/string.zig
+++ b/src/string.zig
@@ -91,14 +91,24 @@ pub fn packStringLiteral(writer: *std.Io.Writer, comptime value: []const u8) !vo
     try writer.writeAll(&bytes);
 }
 
-pub fn unpackString(reader: *std.Io.Reader, allocator: std.mem.Allocator) ![]u8 {
-    const len = try unpackStringHeader(reader, u32);
+/// Like `unpackString`, but `T` may be optional, in which case a nil header
+/// decodes to null. Lets a caller hand an optional type straight down instead
+/// of testing for nil itself, the way the other `unpack*` entry points do.
+pub fn unpackStringValue(reader: *std.Io.Reader, allocator: std.mem.Allocator, comptime T: type) !T {
+    const len = if (isOptional(T))
+        try unpackStringHeader(reader, ?u32) orelse return null
+    else
+        try unpackStringHeader(reader, u32);
 
     const data = try allocator.alloc(u8, len);
     errdefer allocator.free(data);
 
     try reader.readSliceAll(data);
     return data;
+}
+
+pub fn unpackString(reader: *std.Io.Reader, allocator: std.mem.Allocator) ![]u8 {
+    return unpackStringValue(reader, allocator, []u8);
 }
 
 /// Unpacks a string without copying it, borrowing the reader's buffer. The

--- a/src/struct.zig
+++ b/src/struct.zig
@@ -9,6 +9,7 @@ const NoAllocator = @import("utils.zig").NoAllocator;
 
 const maybePackNull = @import("null.zig").maybePackNull;
 const maybeUnpackNull = @import("null.zig").maybeUnpackNull;
+const unpackNullIfPresent = @import("null.zig").unpackNullIfPresent;
 
 const packMapHeader = @import("map.zig").packMapHeader;
 const unpackMapHeader = @import("map.zig").unpackMapHeader;
@@ -290,6 +291,10 @@ pub fn unpackStruct(reader: *std.Io.Reader, allocator: std.mem.Allocator, compti
 
     const has_custom_read_fn = std.meta.hasFn(Type, "msgpackRead");
     if (has_custom_read_fn) {
+        // A custom reader decides its own encoding, so it cannot be asked to
+        // recognise a nil. The formats below carry optionality in their own
+        // header, but here the check has to happen before handing over.
+        if (isOptional(T) and try unpackNullIfPresent(reader)) return null;
         return try Type.msgpackRead(unpacker(reader, allocator));
     } else {
         const format = comptime if (std.meta.hasFn(Type, "msgpackFormat")) Type.msgpackFormat() else default_struct_format;
@@ -388,6 +393,43 @@ test "readStruct: optional custom reader" {
     const decoded = try unpackStruct(&reader, std.testing.allocator, ?Msg);
 
     try std.testing.expectEqual(@as(?Msg, Msg{ .a = 42 }), decoded);
+}
+
+test "readStruct: optional custom reader accepts nil" {
+    // A custom reader defines its own encoding and cannot be asked to
+    // recognise a nil, so the optional has to be resolved before it is called.
+    const Msg = struct {
+        a: u32,
+
+        pub fn msgpackRead(unpacker_value: anytype) !@This() {
+            return .{ .a = try unpacker_value.readInt(u32) };
+        }
+    };
+
+    const packed_nil = [_]u8{0xc0};
+    var reader = std.Io.Reader.fixed(&packed_nil);
+    try std.testing.expectEqual(
+        @as(?Msg, null),
+        try unpackStruct(&reader, std.testing.allocator, ?Msg),
+    );
+    try std.testing.expectEqual(0, reader.bufferedLen());
+}
+
+test "readStruct: non-optional custom reader still rejects nil" {
+    const Msg = struct {
+        a: u32,
+
+        pub fn msgpackRead(unpacker_value: anytype) !@This() {
+            return .{ .a = try unpacker_value.readInt(u32) };
+        }
+    };
+
+    const packed_nil = [_]u8{0xc0};
+    var reader = std.Io.Reader.fixed(&packed_nil);
+    try std.testing.expectError(
+        error.Null,
+        unpackStruct(&reader, std.testing.allocator, Msg),
+    );
 }
 
 test "writeStruct: map by field_name" {


### PR DESCRIPTION
Every `unpack*` leaf already decodes a nil header to null, as one more case of the header switch it performs anyway:

```
bool.zig:43   else => return maybeUnpackNull(header, T)
int.zig:202   else => return maybeUnpackNull(header, T)
float.zig:65  string.zig:55  binary.zig:49  array.zig:53  map.zig:54
```

`unpackAny` never used any of it. Its optional branch peeked for a nil itself, and on anything else called `unpackAny` again with `opt_info.child` — stripping the optional, so the leaf received a non-optional type and its own nil handling was dead code on that path. Two mechanisms for the same job, and the cheaper one unused.

This dispatches on the shape underneath the optional and passes `T` down intact. The peek goes away, and the leaf handles nil as part of the switch it was already performing.

## Measurement

Wall-clock at this scale turned out to be unusable — a control struct with no optionals moved 17% between builds, so code layout was swamping the effect. These are callgrind instruction counts, which are deterministic:

| case | before | after | |
|---|---|---|---|
| struct, 8 optional fields (present) | 886.01 | 727.01 | **−17.9%** |
| struct, 8 plain fields (control) | 787.01 | 784.01 | −0.4% |
| struct, 16 plain fields (control) | 1525.02 | 1524.02 | −0.1% |
| bare `?u32` at top level | 47.00 | 48.00 | +2.1% |

Reproduced across three independent builds — −18.1%, −17.9%, −17.8% on the optional struct — with the controls staying flat, which is what confirms the effect is specific to optionals rather than build luck. About 20 instructions saved per optional field.

The bare top-level `?u32` case is within noise (0.0%, +2.1%, −3.6% across the three builds).

## Two paths that needed their own nil handling

**`unpackString` takes no type parameter**, so it cannot express "optional string". `unpackStringValue` adds one and `unpackString` delegates to it — the public signature is unchanged.

**A type with a custom `msgpackRead`** defines its own encoding and cannot be asked to recognise a nil, so `unpackStruct` resolves the optional before handing over. That case was previously covered by `unpackAny`'s peek. There was already a test for decoding a *value* into an optional custom reader, but none for decoding a *nil*; both directions are covered now, and removing the new check makes the new test fail.

`zig build test`: 177/177 pass, up from 171.
