### PR TITLE
fix: reject enum tags that name no field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Decoding an optional is about 18% cheaper, by letting each type's own unpacker recognise a nil header instead of testing for one beforehand
+
+### Fixed
+- Decoding an enum whose tag names no field returns `error.InvalidEnumTag` instead of being illegal behavior; non-exhaustive enums still accept unknown tags
+
 ## [0.8.0] - 2026-09-04
 
 ### Added

--- a/src/enum.zig
+++ b/src/enum.zig
@@ -59,13 +59,22 @@ pub fn unpackEnum(reader: *std.Io.Reader, comptime T: type) !T {
     // Handle the optional case
     if (@typeInfo(T) == .optional) {
         if (int_value) |value| {
-            return @enumFromInt(value);
+            return try tagFromInt(Type, value);
         } else {
             return null;
         }
     } else {
-        return @enumFromInt(int_value);
+        return tagFromInt(Type, int_value);
     }
+}
+
+/// Converts a tag read off the wire into `T`, rejecting values that name no
+/// field. `@enumFromInt` is illegal behavior for an out-of-range tag on an
+/// exhaustive enum, and the value here comes from the message, so it cannot be
+/// trusted. `std.enums.fromInt` accepts any tag for a non-exhaustive enum,
+/// which is what makes those usable for forward compatibility.
+fn tagFromInt(comptime T: type, value: @typeInfo(T).@"enum".tag_type) !T {
+    return std.enums.fromInt(T, value) orelse error.InvalidEnumTag;
 }
 
 test "getMaxEnumSize" {
@@ -189,4 +198,41 @@ test "getEnumSize with optional" {
     // Test null optional enum size
     const null_value: OptionalEnum = null;
     try std.testing.expectEqual(1, getEnumSize(OptionalEnum, null_value)); // size of null
+}
+
+test "unpackEnum: a tag naming no field is rejected" {
+    const Status = enum(u8) { pending = 1, active = 2 };
+
+    // 3 is a valid u8 but names no field. Before this was checked,
+    // @enumFromInt made it illegal behavior rather than an error.
+    const packed_unknown = [_]u8{0x03};
+    var reader = std.Io.Reader.fixed(&packed_unknown);
+    try std.testing.expectError(error.InvalidEnumTag, unpackEnum(&reader, Status));
+}
+
+test "unpackEnum: optional enum rejects a tag naming no field" {
+    const Status = enum(u8) { pending = 1, active = 2 };
+
+    const packed_unknown = [_]u8{0x03};
+    var reader = std.Io.Reader.fixed(&packed_unknown);
+    try std.testing.expectError(error.InvalidEnumTag, unpackEnum(&reader, ?Status));
+}
+
+test "unpackEnum: a non-exhaustive enum accepts an unknown tag" {
+    // The point of a non-exhaustive enum is to survive tags added later, so
+    // an unrecognised value has to round trip rather than error.
+    const Status = enum(u8) { pending = 1, active = 2, _ };
+
+    const packed_unknown = [_]u8{0x63};
+    var reader = std.Io.Reader.fixed(&packed_unknown);
+    const value = try unpackEnum(&reader, Status);
+    try std.testing.expectEqual(@as(u8, 99), @intFromEnum(value));
+}
+
+test "unpackEnum: valid tags still decode" {
+    const Status = enum(u8) { pending = 1, active = 2 };
+
+    const packed_active = [_]u8{0x02};
+    var reader = std.Io.Reader.fixed(&packed_active);
+    try std.testing.expectEqual(Status.active, try unpackEnum(&reader, Status));
 }


### PR DESCRIPTION
Fixes #33.

`unpackEnum` ended with a bare `@enumFromInt` on a value taken straight off the wire:

```zig
const int_value = try unpackInt(reader, OptionalTagType);
...
return @enumFromInt(int_value);
```

For an exhaustive enum, `@enumFromInt` with a value that names no field is illegal behavior — a safety panic in Debug and ReleaseSafe, undefined in ReleaseFast. Any message from a peer on a newer schema, a corrupted frame, or a hostile sender reaches it.

Without the check, the new tests don't fail an assertion, they abort:

```
error: 'unpackEnum: a tag naming no field is rejected' terminated with signal ABRT
       thread panic: invalid enum value
```

Now routed through `std.enums.fromInt`, returning `error.InvalidEnumTag` — consistent with `error.InvalidFormat`, `error.UnknownStructField` and `error.IntegerOverflow` elsewhere in the decoder.

## Non-exhaustive enums

The issue asked whether `enum(u8) { a, b, _ }` should keep accepting unknown tags. `std.enums.fromInt` answers it: for a non-exhaustive enum it casts and returns the value, only validating against named fields for exhaustive ones.

That's the behaviour I'd want anyway. Rejecting unknown tags on a non-exhaustive enum would defeat its purpose — it's how you express a tag set that may grow, which is the same forward-compatibility problem `skip_unknown_fields` solves one level up. So both are covered by tests: exhaustive rejects, non-exhaustive round-trips an unrecognised value.

`std.meta.intToEnum` no longer exists in Zig 0.16; `std.enums.fromInt` is its replacement.

## Also

Adds the `[Unreleased]` changelog section, covering this and #38 — following the earlier preference for recording entries alongside the change rather than in a separate PR.

`zig build test`: 181/181 pass, up from 177.
