### PR TITLE
fix: make the unsupported-int-width message compile

### DIFF
--- a/src/int.zig
+++ b/src/int.zig
@@ -47,7 +47,7 @@ pub fn getIntSize(comptime T: type, value: T) usize {
         if (bits == 64 or value >= std.math.minInt(i64) and value <= std.math.maxInt(i64)) {
             return 1 + @sizeOf(i64);
         }
-        @compileError("Unsupported signed int with " ++ type_info.int.bits ++ "bits");
+        @compileError(std.fmt.comptimePrint("Unsupported signed int with {d} bits", .{type_info.int.bits}));
     } else {
         if (value <= 127) {
             return 1;
@@ -64,7 +64,7 @@ pub fn getIntSize(comptime T: type, value: T) usize {
         if (bits == 64 or value <= std.math.maxInt(u64)) {
             return 1 + @sizeOf(u64);
         }
-        @compileError("Unsupported integer size of " ++ bits ++ "bits");
+        @compileError(std.fmt.comptimePrint("Unsupported unsigned int with {d} bits", .{bits}));
     }
 }
 
@@ -96,7 +96,7 @@ pub fn packInt(writer: *std.Io.Writer, comptime T: type, value_or_maybe_null: T)
         if (bits == 64 or value >= std.math.minInt(i64) and value <= std.math.maxInt(i64)) {
             return packFixedSizeInt(writer, i64, @intCast(value));
         }
-        @compileError("Unsupported signed int with " ++ type_info.int.bits ++ "bits");
+        @compileError(std.fmt.comptimePrint("Unsupported signed int with {d} bits", .{type_info.int.bits}));
     } else {
         if (value <= 127) {
             return writer.writeByte(@bitCast(@as(u8, @intCast(value))));
@@ -113,7 +113,7 @@ pub fn packInt(writer: *std.Io.Writer, comptime T: type, value_or_maybe_null: T)
         if (bits == 64 or value <= std.math.maxInt(u64)) {
             return packFixedSizeInt(writer, u64, @intCast(value));
         }
-        @compileError("Unsupported integer size of " ++ bits ++ "bits");
+        @compileError(std.fmt.comptimePrint("Unsupported unsigned int with {d} bits", .{bits}));
     }
 }
 
@@ -130,7 +130,7 @@ inline fn resolveFixedSizeIntHeader(comptime T: type) u8 {
                 16 => return hdrs.INT16,
                 32 => return hdrs.INT32,
                 64 => return hdrs.INT64,
-                else => @compileError("Unsupported signed int with " ++ type_info.int.bits ++ "bits"),
+                else => @compileError(std.fmt.comptimePrint("Unsupported signed int with {d} bits", .{type_info.int.bits})),
             }
         },
         .unsigned => {
@@ -139,7 +139,7 @@ inline fn resolveFixedSizeIntHeader(comptime T: type) u8 {
                 16 => return hdrs.UINT16,
                 32 => return hdrs.UINT32,
                 64 => return hdrs.UINT64,
-                else => @compileError("Unsupported unsigned int with " ++ type_info.int.bits ++ "bits"),
+                else => @compileError(std.fmt.comptimePrint("Unsupported unsigned int with {d} bits", .{type_info.int.bits})),
             }
         },
     }


### PR DESCRIPTION
Fixes #34.

`packInt` and `getIntSize` both end their signed and unsigned branches with a `@compileError` that concatenates a `u16` onto a string:

```zig
@compileError("Unsupported signed int with " ++ type_info.int.bits ++ "bits");
```

`++` needs indexable operands, so it fails on its own terms before the message is ever produced. Before:

```
src/int.zig:99:70: error: expected indexable; found 'u16'
```

After:

```
src/int.zig:99:9: error: Unsupported signed int with 96 bits
```

Six sites — both functions, plus both branches of `resolveFixedSizeIntHeader`. `std.fmt.comptimePrint` builds the message properly, and the missing space before `bits` is gone.

Never surfaced because nothing instantiates these with an unsupported width, which is the same reason the defects behind #21, #22 and #23 stayed hidden. It is reachable in practice though: `std.Io.Timestamp` and `std.Io.Duration` are both `struct { nanoseconds: i96 }`, so encoding either one lands exactly here, and a legible error is the difference between "this width is not supported" and a confusing complaint about `++`.

Reproduced and verified with `packInt(&w, i96, 1)`.

No changelog entry — the error text is not user-visible until you hit it, and nothing about the supported widths changed. Happy to add one if you would rather it were recorded.

`zig build test`: 183/183 pass.
