### PR TITLE
chore: remove dead UnionAsMapOptions fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Decoding an optional is about 18% cheaper, by letting each type's own unpacker recognise a nil header instead of testing for one beforehand
 
+### Removed
+- `omit_nulls` and `omit_defaults` on `UnionAsMapOptions`, which were never read; a union-as-map always writes exactly one entry, so there is nothing to omit
+
 ### Fixed
 - Decoding an enum whose tag names no field returns `error.InvalidEnumTag` instead of being illegal behavior; non-exhaustive enums still accept unknown tags
 

--- a/src/union.zig
+++ b/src/union.zig
@@ -35,8 +35,6 @@ pub const UnionAsMapOptions = struct {
         field_name_prefix: u8,
         field_index,
     },
-    omit_nulls: bool = true,
-    omit_defaults: bool = false,
 };
 
 pub const UnionAsTaggedOptions = struct {


### PR DESCRIPTION
Fixes #36.

```zig
pub const UnionAsMapOptions = struct {
    key: union(enum) { field_name, field_name_prefix: u8, field_index },
    omit_nulls: bool = true,        // never read
    omit_defaults: bool = false,    // never read
};
```

Both are copy-paste from `StructAsMapOptions`, where they are genuinely used by `isStructFieldUsed` on the encode side. Here nothing consults them in either direction.

They are also meaningless in this position: `packUnionAsMap` always writes `packMapHeader(writer, 1)` — one entry, the active variant — so there is nothing to omit.

Same category as the dead surface removed in #27. No behaviour change, since nothing read them.

Breaking only for code that set them explicitly, which could only ever have been a no-op. Recorded in the changelog under Removed.

`zig build test`: 183/183 pass.

Noticed while adding `skip_unknown_fields` in #28 and deferred to keep that PR focused.
