### PR TITLE
test: make TrickleReader honour the destination it is given

### DIFF
--- a/src/msgpack.zig
+++ b/src/msgpack.zig
@@ -306,15 +306,30 @@ const TrickleReader = struct {
         };
     }
 
+    /// Yields one byte per call, to whichever destination the caller asked for.
+    ///
+    /// The two drivers in `std.Io.Reader` want different things. `fillUnbuffered`
+    /// passes an empty `data[0]` and expects the reader's own buffer to grow,
+    /// ignoring the return value. `readSliceShort` passes the caller's remaining
+    /// destination and advances by the returned count, so a byte written
+    /// anywhere else is both lost and miscounted -- and once the reader's buffer
+    /// fills, returning 0 with no progress makes its loop spin forever.
     fn readVec(r: *std.Io.Reader, data: [][]u8) std.Io.Reader.Error!usize {
-        _ = data;
         const self: *TrickleReader = @fieldParentPtr("reader", r);
         if (self.pos >= self.data.len) return error.EndOfStream;
-        if (r.end >= r.buffer.len) return 0;
+
+        if (data.len > 0 and data[0].len > 0) {
+            data[0][0] = self.data[self.pos];
+            self.pos += 1;
+            return 1;
+        }
+
+        // `rebase` has already made room for what the caller asked to buffer.
+        std.debug.assert(r.end < r.buffer.len);
         r.buffer[r.end] = self.data[self.pos];
         r.end += 1;
         self.pos += 1;
-        return 1;
+        return 0;
     }
 
     fn stream(_: *std.Io.Reader, _: *std.Io.Writer, _: std.Io.Limit) std.Io.Reader.StreamError!usize {
@@ -391,6 +406,27 @@ test "decode a key too long for the reader buffer errors, never panics" {
         var trickle = TrickleReader.init(&buffer, bytes);
         const decoded = try decodeLeaky(LongKey, std.testing.allocator, &trickle.reader);
         try std.testing.expectEqualDeep(value, decoded);
+    }
+}
+
+test "decode a string value larger than the reader buffer" {
+    // String *values* are copied out rather than borrowed, so unlike map keys
+    // they have no size limit relative to the reader's buffer. This drives
+    // `readSliceShort`, which hands the reader the caller's destination rather
+    // than asking it to buffer.
+    const Msg = struct { s: []const u8 };
+    const long = "a" ** 200;
+    const value = Msg{ .s = long };
+
+    var encoded: [256]u8 = undefined;
+    const bytes = try encodeToBuffer(value, &encoded);
+
+    for ([_]usize{ 16, 33, 64 }) |buffer_len| {
+        var buffer: [64]u8 = undefined;
+        var trickle = TrickleReader.init(buffer[0..buffer_len], bytes);
+        const decoded = try decodeLeaky(Msg, std.testing.allocator, &trickle.reader);
+        defer std.testing.allocator.free(decoded.s);
+        try std.testing.expectEqualStrings(long, decoded.s);
     }
 }
 


### PR DESCRIPTION
Fixes #44.

`TrickleReader` always wrote its byte into the reader's own buffer and returned 1. That suits only one of the two drivers in `std.Io.Reader`:

- **`fillUnbuffered`** passes an empty `data[0]`, expects `r.buffer` to grow, and ignores the return value
- **`readSliceShort`** passes the caller's remaining destination and advances by the returned count

Under the second, the old implementation wrote the byte somewhere the caller never looks *while claiming it had been delivered* — and once `r.buffer` filled it returned 0 with no progress, so the loop spun forever.

```zig
fn readVec(r: *std.Io.Reader, data: [][]u8) std.Io.Reader.Error!usize {
    _ = data;                                   // <- the destination, discarded
    ...
    if (r.end >= r.buffer.len) return 0;        // <- no progress, caller loops
    r.buffer[r.end] = self.data[self.pos];
    ...
    return 1;                                   // <- but nothing reached data[0]
}
```

Now it branches on whether a destination was offered, and returns 0 for buffer writes as the vtable contract describes ("Implementations may ignore `data`, writing directly to `Reader.buffer` ... and returning 0").

## Why it went unnoticed

Every existing test keeps values inside the buffer, where `readSliceShort`'s opening memcpy satisfies the whole read and the loop never runs. The remaining tests assert `error.ReaderBufferTooSmall`, which the library raises before reading. So the helper was only ever exercised below the threshold its own doc comment advertises — that the buffer can be smaller than the value being decoded.

The hang is also the worst failure mode: no output, no assertion, just a timeout, with suspicion landing on the library rather than the harness.

## The test it was blocking

A 200-byte string decoded through buffers of 16, 33 and 64 bytes. String *values* are copied out rather than borrowed, so unlike map keys they have no size limit relative to the reader's buffer — a real case with no coverage until now.

Verified both ways: with the old `readVec` the new test does not terminate (killed at 45s); with the fix the suite runs in the usual few hundred milliseconds.

## Still not implemented

`stream` and `discard` return `error.EndOfStream` unconditionally. Nothing needs them yet, but `skipAny` uses `discardAll`, so a future skip test against this reader will fail — loudly and immediately, not by hanging.

`zig build test`: 184/184 pass, up from 183.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decoding of string values larger than the reader’s buffer.
  * Fixed handling of reads into caller-provided destination slices.
* **Tests**
  * Added coverage for decoding oversized strings through the destination-slice path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->