### PR TITLE
test: implement TrickleReader as a stream, not a readVec

### DIFF
--- a/src/msgpack.zig
+++ b/src/msgpack.zig
@@ -293,12 +293,7 @@ const TrickleReader = struct {
         return .{
             .data = data,
             .reader = .{
-                .vtable = &.{
-                    .stream = stream,
-                    .discard = discard,
-                    .readVec = readVec,
-                    .rebase = std.Io.Reader.defaultRebase,
-                },
+                .vtable = &.{ .stream = stream },
                 .buffer = buffer,
                 .seek = 0,
                 .end = 0,
@@ -306,23 +301,19 @@ const TrickleReader = struct {
         };
     }
 
-    fn readVec(r: *std.Io.Reader, data: [][]u8) std.Io.Reader.Error!usize {
-        _ = data;
+    /// Hands over a single byte per call. `stream` is the only operation a
+    /// `std.Io.Reader` must provide; `readVec`, `discard` and `rebase` all
+    /// default to implementations derived from it, so leaving them alone is
+    /// what makes this reader behave correctly everywhere rather than only in
+    /// the situations it was tried in.
+    fn stream(r: *std.Io.Reader, w: *std.Io.Writer, limit: std.Io.Limit) std.Io.Reader.StreamError!usize {
         const self: *TrickleReader = @fieldParentPtr("reader", r);
         if (self.pos >= self.data.len) return error.EndOfStream;
-        if (r.end >= r.buffer.len) return 0;
-        r.buffer[r.end] = self.data[self.pos];
-        r.end += 1;
+        if (!limit.nonzero()) return 0;
+
+        try w.writeByte(self.data[self.pos]);
         self.pos += 1;
         return 1;
-    }
-
-    fn stream(_: *std.Io.Reader, _: *std.Io.Writer, _: std.Io.Limit) std.Io.Reader.StreamError!usize {
-        return error.EndOfStream;
-    }
-
-    fn discard(_: *std.Io.Reader, _: std.Io.Limit) std.Io.Reader.Error!usize {
-        return error.EndOfStream;
     }
 };
 
@@ -392,6 +383,45 @@ test "decode a key too long for the reader buffer errors, never panics" {
         const decoded = try decodeLeaky(LongKey, std.testing.allocator, &trickle.reader);
         try std.testing.expectEqualDeep(value, decoded);
     }
+}
+
+test "decode a string value larger than the reader buffer" {
+    // String *values* are copied out rather than borrowed, so unlike map keys
+    // they have no size limit relative to the reader's buffer. This drives
+    // `readSliceShort`, which hands the reader the caller's destination rather
+    // than asking it to buffer.
+    const Msg = struct { s: []const u8 };
+    const long = "a" ** 200;
+    const value = Msg{ .s = long };
+
+    var encoded: [256]u8 = undefined;
+    const bytes = try encodeToBuffer(value, &encoded);
+
+    for ([_]usize{ 16, 33, 64 }) |buffer_len| {
+        var buffer: [64]u8 = undefined;
+        var trickle = TrickleReader.init(buffer[0..buffer_len], bytes);
+        const decoded = try decodeLeaky(Msg, std.testing.allocator, &trickle.reader);
+        defer std.testing.allocator.free(decoded.s);
+        try std.testing.expectEqualStrings(long, decoded.s);
+    }
+}
+
+test "skip a value larger than the reader buffer" {
+    // Exercises the reader's `discard`, which now comes from the std default
+    // built on `stream`. With `discard` stubbed out this returned
+    // `error.EndOfStream` even though the bytes were available.
+    var encoded: [512]u8 = undefined;
+    var writer = std.Io.Writer.fixed(&encoded);
+    try packString(&writer, "a" ** 200);
+    try packInt(&writer, u8, 42);
+    const bytes = writer.buffered();
+
+    var buffer: [16]u8 = undefined;
+    var trickle = TrickleReader.init(&buffer, bytes);
+
+    try skipAny(&trickle.reader);
+    // The skip must land exactly on the next value, not past it or short of it.
+    try std.testing.expectEqual(@as(u8, 42), try unpackInt(&trickle.reader, u8));
 }
 
 test "encode/decode" {


### PR DESCRIPTION
Fixes #44. Replaces #45, which fixed one symptom while leaving the cause in place.

`stream` is the only operation a `std.Io.Reader` must supply — `discard`, `readVec` and `rebase` all default to implementations derived from it:

```zig
stream:  *const fn (...)                      // no default
discard: *const fn (...) = defaultDiscard
readVec: *const fn (...) = defaultReadVec
rebase:  *const fn (...) = defaultRebase
```

`TrickleReader` had that inverted. It stubbed `stream` out to return `error.EndOfStream` and hand-wrote `readVec` and `discard` instead, so it was correct only in the situations it happened to be tried in. Every problem with it followed from that:

- **`readVec`** discarded the destination it was handed and returned 1 anyway. Under `readSliceShort` that both lost the byte and miscounted it; once the reader's own buffer filled it returned 0 with no progress and the caller spun forever.
- **`discard`** returned `EndOfStream` whenever a skip reached past what was already buffered, so `skipAny` could not run against it.
- **`stream`** would have broken anything reaching for `streamRemaining` or `readAlloc`.

Implementing `stream` and deleting the other two overrides is **less code and correct everywhere**. `defaultReadVec` already does the empty-vs-non-empty destination handling, and better — it picks whichever of `data[0]` or `r.buffer` is larger. `defaultDiscard` routes through a `Writer.Discarding`.

```zig
fn stream(r: *std.Io.Reader, w: *std.Io.Writer, limit: std.Io.Limit) std.Io.Reader.StreamError!usize {
    const self: *TrickleReader = @fieldParentPtr("reader", r);
    if (self.pos >= self.data.len) return error.EndOfStream;
    if (!limit.nonzero()) return 0;

    try w.writeByte(self.data[self.pos]);
    self.pos += 1;
    return 1;
}
```

Net −19 lines from the type, +2 tests.

## Two tests this unblocks

Neither could run before:

- **A 200-byte string through buffers of 16, 33 and 64 bytes.** String *values* are copied out rather than borrowed, so unlike map keys they have no size limit relative to the reader's buffer. This used to hang; I had to kill the run at 45s.
- **`skipAny` over a value larger than the buffer**, checking it lands exactly on the value that follows. This used to fail with `error.EndOfStream` despite the bytes being available — which matters now that `skip_unknown_fields` is built on `skipAny`.

## Why #45 was the wrong fix

It made `readVec` handle both drivers correctly, which removed the hang, but left `discard` and `stream` stubbed. The next gap would have been `discard` the moment someone tested `skip_unknown_fields` against a streaming reader — and the one after that, `stream`. Deriving everything from one correct primitive removes the whole class instead of one instance.

`zig build test`: 185/185 pass, up from 183.
